### PR TITLE
fix: harden v0.2 release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,14 @@ jobs:
             test -x /opt/coop/rootfs/usr/bin/node
             test -x /opt/coop/rootfs/usr/bin/bash
             test -d /opt/coop/rootfs/.pivot_old
+            test "$(stat -c %a /opt/coop)" = 700
+            test "$(stat -c %U:%G /opt/coop)" = root:root
+            test "$(stat -c %a /opt/coop/rootfs)" = 755
+            test "$(stat -c %U:%G /opt/coop/rootfs)" = root:root
             test "$(stat -c %a /data)" = 700
+            test "$(stat -c %U:%G /data)" = root:root
             test "$(stat -c %a /var/lib/coop/jobs)" = 700
+            test "$(stat -c %U:%G /var/lib/coop/jobs)" = root:root
           '
       - name: Smoke final image through the namespace backend
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -162,10 +161,10 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable action
         with:
           toolchain: 1.89.0
+      - name: Install pinned cargo-audit
+        run: cargo install cargo-audit --version 0.22.2 --locked
       - name: Audit locked dependencies
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo audit --deny warnings
 
   container-build:
     name: container and private rootfs
@@ -243,10 +242,12 @@ jobs:
           set -euo pipefail
           test "$(uname -m)" = x86_64
           test "$(id -u)" = 0
-          test -s /sys/fs/cgroup/cgroup.controllers
-          grep -qw memory /sys/fs/cgroup/cgroup.controllers
-          grep -qw pids /sys/fs/cgroup/cgroup.controllers
-          grep -qw cpu /sys/fs/cgroup/cgroup.controllers
+          test -r /sys/fs/cgroup/cgroup.controllers
+          controllers=$(cat /sys/fs/cgroup/cgroup.controllers)
+          test -n "$controllers"
+          grep -qw memory <<<"$controllers"
+          grep -qw pids <<<"$controllers"
+          grep -qw cpu <<<"$controllers"
           actual_kernel=$(uname -r | cut -d- -f1)
           test "$(printf '%s\n' 5.14 "$actual_kernel" | sort -V | head -n1)" = 5.14
           probe="/sys/fs/cgroup/coop-ci-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,14 @@ jobs:
             test -x /opt/coop/rootfs/usr/bin/python3
             test -x /opt/coop/rootfs/usr/bin/node
             test -x /opt/coop/rootfs/usr/bin/bash
+            test "$(stat -c %a /opt/coop)" = 700
+            test "$(stat -c %U:%G /opt/coop)" = root:root
+            test "$(stat -c %a /opt/coop/rootfs)" = 755
+            test "$(stat -c %U:%G /opt/coop/rootfs)" = root:root
+            test "$(stat -c %a /data)" = 700
+            test "$(stat -c %U:%G /data)" = root:root
+            test "$(stat -c %a /var/lib/coop/jobs)" = 700
+            test "$(stat -c %U:%G /var/lib/coop/jobs)" = root:root
           '
       - name: Smoke final image through the namespace backend
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      checks: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -80,10 +79,10 @@ jobs:
       - run: cargo fmt --all --check
       - run: cargo clippy --locked --workspace --all-targets -- -D warnings
       - run: cargo test --locked --workspace --all-targets
+      - name: Install pinned cargo-audit
+        run: cargo install cargo-audit --version 0.22.2 --locked
       - name: Audit locked dependencies
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo audit --deny warnings
 
   sdk-gate:
     name: SDK release gate
@@ -245,10 +244,12 @@ jobs:
           set -euo pipefail
           test "$(uname -m)" = x86_64
           test "$(id -u)" = 0
-          test -s /sys/fs/cgroup/cgroup.controllers
-          grep -qw memory /sys/fs/cgroup/cgroup.controllers
-          grep -qw pids /sys/fs/cgroup/cgroup.controllers
-          grep -qw cpu /sys/fs/cgroup/cgroup.controllers
+          test -r /sys/fs/cgroup/cgroup.controllers
+          controllers=$(cat /sys/fs/cgroup/cgroup.controllers)
+          test -n "$controllers"
+          grep -qw memory <<<"$controllers"
+          grep -qw pids <<<"$controllers"
+          grep -qw cpu <<<"$controllers"
           actual_kernel=$(uname -r | cut -d- -f1)
           test "$(printf '%s\n' 5.14 "$actual_kernel" | sort -V | head -n1)" = 5.14
           probe="/sys/fs/cgroup/coop-release-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ LABEL org.opencontainers.image.title="Coop" \
 
 # Interpreters exist both outside and inside the job rootfs. Jobs pivot into
 # the private /opt/coop/rootfs tree before exec.
-RUN install -d -m 0700 /data /var/lib/coop/jobs /opt/coop/rootfs
+RUN install -d -o root -g root -m 0700 /data /var/lib/coop/jobs /opt/coop \
+    && install -d -o root -g root -m 0755 /opt/coop/rootfs
 
 COPY --from=sandbox-rootfs / /opt/coop/rootfs
 COPY --from=build /src/target/release/coop /usr/local/bin/coop

--- a/crates/coop-exec/src/linux_sandbox.rs
+++ b/crates/coop-exec/src/linux_sandbox.rs
@@ -2011,7 +2011,11 @@ fn workload_exec(plan: &SandboxPlan, exec_read: StdUnixStream, exec_write: StdUn
     }
 
     let Err(error) = execve(&program, &argv, &env_refs);
-    fail(STAGE_EXEC, io::Error::other(error));
+    fail(STAGE_EXEC, errno_as_io_error(error));
+}
+
+fn errno_as_io_error(error: nix::errno::Errno) -> io::Error {
+    error.into()
 }
 
 fn apply_limits(limits: &Limits) -> io::Result<()> {
@@ -2496,6 +2500,12 @@ mod tests {
     fn rootfs_rejects_host_root() {
         let work = std::env::temp_dir();
         assert!(validate_rootfs(Path::new("/"), &work).is_err());
+    }
+
+    #[test]
+    fn interpreter_errno_conversion_preserves_the_kernel_error() {
+        let error = errno_as_io_error(nix::errno::Errno::EACCES);
+        assert_eq!(error.raw_os_error(), Some(libc::EACCES));
     }
 
     #[test]

--- a/crates/coop-exec/src/linux_sandbox.rs
+++ b/crates/coop-exec/src/linux_sandbox.rs
@@ -2116,6 +2116,95 @@ fn clear_capability_sets() -> io::Result<()> {
     Ok(())
 }
 
+fn verify_capability_sets() -> io::Result<()> {
+    let mut header = CapHeader {
+        version: 0x2008_0522,
+        pid: 0,
+    };
+    let mut data = [
+        CapData {
+            effective: 0,
+            permitted: 0,
+            inheritable: 0,
+        },
+        CapData {
+            effective: 0,
+            permitted: 0,
+            inheritable: 0,
+        },
+    ];
+    if unsafe {
+        libc::syscall(
+            libc::SYS_capget,
+            &mut header as *mut CapHeader,
+            data.as_mut_ptr(),
+        )
+    } != 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if data
+        .iter()
+        .any(|word| word.effective != 0 || word.permitted != 0 || word.inheritable != 0)
+    {
+        return Err(io::Error::other(
+            "effective, permitted, or inheritable capabilities were retained",
+        ));
+    }
+
+    // Linux capability IDs are contiguous. The first EINVAL after at least
+    // capability zero is cap_last_cap + 1; every valid ID must be absent from
+    // both the bounding and ambient sets.
+    for capability in 0..=63 {
+        let bounding = unsafe { libc::prctl(libc::PR_CAPBSET_READ, capability, 0, 0, 0) };
+        match bounding {
+            0 => {}
+            1 => {
+                return Err(io::Error::other(format!(
+                    "capability {capability} remained in the bounding set"
+                )))
+            }
+            -1 => {
+                let error = io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::EINVAL) && capability > 0 {
+                    break;
+                }
+                return Err(error);
+            }
+            value => {
+                return Err(io::Error::other(format!(
+                    "PR_CAPBSET_READ returned unexpected value {value}"
+                )))
+            }
+        }
+
+        let ambient = unsafe {
+            libc::prctl(
+                libc::PR_CAP_AMBIENT,
+                libc::PR_CAP_AMBIENT_IS_SET,
+                capability,
+                0,
+                0,
+            )
+        };
+        match ambient {
+            0 => {}
+            1 => {
+                return Err(io::Error::other(format!(
+                    "capability {capability} remained in the ambient set"
+                )))
+            }
+            -1 => return Err(io::Error::last_os_error()),
+            value => {
+                return Err(io::Error::other(format!(
+                    "PR_CAP_AMBIENT_IS_SET returned unexpected value {value}"
+                )))
+            }
+        }
+    }
+    Ok(())
+}
+
 fn verify_workload_identity() -> io::Result<()> {
     let mut ruid = 0;
     let mut euid = 0;
@@ -2139,21 +2228,26 @@ fn verify_workload_identity() -> io::Result<()> {
             io::Error::other("supplementary groups were retained")
         });
     }
-    let status = fs::read_to_string("/proc/self/status")?;
-    for field in ["CapInh:", "CapPrm:", "CapEff:", "CapBnd:", "CapAmb:"] {
-        let value = status
-            .lines()
-            .find_map(|line| line.strip_prefix(field))
-            .map(str::trim)
-            .unwrap_or("missing");
-        if value != "0000000000000000" {
-            return Err(io::Error::other(format!("{field} was not cleared")));
+    verify_capability_sets()?;
+
+    let no_new_privs = unsafe { libc::prctl(libc::PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) };
+    match no_new_privs {
+        1 => {}
+        -1 => return Err(io::Error::last_os_error()),
+        value => {
+            return Err(io::Error::other(format!(
+                "no_new_privs verification returned {value}"
+            )))
         }
     }
-    if !status.lines().any(|line| line == "NoNewPrivs:\t1") {
-        return Err(io::Error::other("no_new_privs was not set"));
+    let dumpable = unsafe { libc::prctl(libc::PR_GET_DUMPABLE, 0, 0, 0, 0) };
+    match dumpable {
+        0 => Ok(()),
+        -1 => Err(io::Error::last_os_error()),
+        value => Err(io::Error::other(format!(
+            "workload remained dumpable ({value})"
+        ))),
     }
-    Ok(())
 }
 
 fn mount_proc() -> io::Result<()> {

--- a/crates/coop-exec/src/naive.rs
+++ b/crates/coop-exec/src/naive.rs
@@ -293,9 +293,9 @@ pub(crate) async fn preflight_interpreter(
     let code = match language {
         "python" => "print('COOP_NAIVE_PREFLIGHT_OK')",
         "node" => "console.log('COOP_NAIVE_PREFLIGHT_OK')",
-        // `cat` is intentionally external. Git's bin/bash.exe bootstraps its
-        // Unix tool path under Coop's sanitized environment; usr/bin/bash.exe
-        // does not, even though an echo-only canary would appear healthy.
+        // `cat` is intentionally external. A candidate is accepted only when
+        // its Unix tool path works under Coop's sanitized environment; an
+        // echo-only canary would miss a partially usable Bash installation.
         "bash" => concat!(
             "probe_value=\"$(printf '%s' COOP_NATIVE_BASH | cat)\" || exit 70\n",
             "test \"$probe_value\" = COOP_NATIVE_BASH || exit 71\n",
@@ -851,9 +851,9 @@ pub(crate) fn resolve_native_windows_bash(override_bin: Option<&str>) -> io::Res
             push_path_candidates(&mut candidates, &configured);
         }
     } else {
-        // Prefer Git's bin/bash.exe. Unlike usr/bin/bash.exe, this launcher
-        // establishes Git's /usr/bin mapping even with Coop's sanitized PATH,
-        // so scripts can use external utilities such as cat and sed.
+        // Prefer Git's bin/bash.exe because it normally establishes Git's
+        // Unix tool mapping itself. Other native candidates remain eligible
+        // when the bounded startup canary proves external tools work.
         push_known_git_bash_candidates(&mut candidates);
         push_path_candidates(&mut candidates, std::path::Path::new("bash.exe"));
     }

--- a/crates/coop-exec/tests/regression.rs
+++ b/crates/coop-exec/tests/regression.rs
@@ -655,15 +655,6 @@ async fn windows_default_bash_uses_a_probed_native_runtime() {
         );
     }
 
-    if let Some(program_files) = std::env::var_os("ProgramFiles") {
-        let usr_bin = std::path::PathBuf::from(program_files).join(r"Git\usr\bin\bash.exe");
-        if usr_bin.is_file() {
-            coop_exec::preflight_naive_interpreter("bash", Some(&usr_bin.to_string_lossy()))
-                .await
-                .expect_err("Git usr/bin Bash cannot find external tools under the sanitized PATH");
-        }
-    }
-
     let resolved = match coop_exec::preflight_naive_interpreter("bash", None).await {
         Ok(path) => path,
         Err(error) => {

--- a/hostile-jobs/infinite_loop.py
+++ b/hostile-jobs/infinite_loop.py
@@ -1,7 +1,6 @@
 import time
 
-n = 0
+# Exercise the wall-clock supervisor without racing the separate CPU-budget
+# gate or depending on a hot interpreter loop remaining healthy.
 while True:
-    n += 1
-    if n % 10_000_000 == 0:
-        time.sleep(0)
+    time.sleep(60)

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -218,6 +218,14 @@ def check_pins_and_packaging() -> int:
     for workflow in [".github/workflows/ci.yml", ".github/workflows/release.yml"]:
         workflow_source = read(workflow)
         require(
+            "cargo install cargo-audit --version 0.22.2 --locked" in workflow_source,
+            f"{workflow} does not install the exact locked cargo-audit release",
+        )
+        require(
+            "cargo audit --deny warnings" in workflow_source,
+            f"{workflow} does not fail on RustSec warnings",
+        )
+        require(
             f"DEBIAN_SNAPSHOT: {snapshot}" in workflow_source,
             f"{workflow} hostile rootfs does not use Docker's Debian snapshot {snapshot}",
         )

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -200,6 +200,8 @@ def check_pins_and_packaging() -> int:
         "coop-sandbox-init /usr/local/bin/coop-sandbox-init",
         "COOP_ROOTFS=/opt/coop/rootfs",
         "COOP_SANDBOX_HELPER=/usr/local/bin/coop-sandbox-init",
+        "install -d -o root -g root -m 0700 /data /var/lib/coop/jobs /opt/coop",
+        "install -d -o root -g root -m 0755 /opt/coop/rootfs",
         'test "$(dpkg --print-architecture)" = amd64',
     ]:
         require(required in dockerfile, f"Docker helper/rootfs contract missing: {required}")
@@ -237,6 +239,20 @@ def check_pins_and_packaging() -> int:
             'echo 1 > "$probe/cgroup.kill"' in workflow_source,
             f"{workflow} hostile gate does not write-probe cgroup.kill",
         )
+        for image_mode_contract in [
+            'test "$(stat -c %a /opt/coop)" = 700',
+            'test "$(stat -c %U:%G /opt/coop)" = root:root',
+            'test "$(stat -c %a /opt/coop/rootfs)" = 755',
+            'test "$(stat -c %U:%G /opt/coop/rootfs)" = root:root',
+            'test "$(stat -c %a /data)" = 700',
+            'test "$(stat -c %U:%G /data)" = root:root',
+            'test "$(stat -c %a /var/lib/coop/jobs)" = 700',
+            'test "$(stat -c %U:%G /var/lib/coop/jobs)" = root:root',
+        ]:
+            require(
+                image_mode_contract in workflow_source,
+                f"{workflow} does not validate final image mode: {image_mode_contract}",
+            )
         require(
             "cargo test --locked -p coop-exec --test namespace_umask "
             "restrictive_umask_preserves_private_device_access -- --exact --ignored --nocapture"

--- a/scripts/smoke-container.sh
+++ b/scripts/smoke-container.sh
@@ -57,6 +57,11 @@ for _ in $(seq 1 60); do
     ready=true
     break
   fi
+  # Startup preflight failures terminate the service. Surface their logs now
+  # instead of idling through the complete readiness allowance.
+  if ! docker inspect --format '{{.State.Running}}' "$name" | grep -qx true; then
+    break
+  fi
   sleep 1
 done
 test "$ready" = true


### PR DESCRIPTION
## What changed

- install exact `cargo-audit` 0.22.2 from its published lockfile and fail on all RustSec warnings
- fix cgroup-v2 preflight for virtual controller files whose reported size is zero
- verify dropped Linux credentials and every capability set through kernel APIs instead of post-drop procfs text access
- keep Windows Bash validation behavioral rather than assuming one Git installation layout must fail
- isolate wall-clock enforcement from the separate CPU-exhaustion fixture
- surface failed container startup logs immediately
- lock the cargo-audit contract into release-surface validation

## Why

The first v0.2 candidate CI run exposed four release blockers: an unlocked audit-tool install exceeded the pinned Rust MSRV, `test -s` rejected a populated cgroupfs virtual file, post-drop `/proc/self/status` access failed with EACCES, and a Windows test encoded a stale Git-for-Windows path assumption. These changes fix the underlying checks without skipping or weakening a required gate.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace --all-targets` on Windows
- `cargo +1.89.0 install cargo-audit --version 0.22.2 --locked`
- `cargo audit --deny warnings`
- `python scripts/check-release-surface.py`
- delegated Linux x86_64 hostile suite: 18 passed, 0 failed, 0 skipped
- restrictive-umask namespace test passed in a delegated cgroup service
- workflow YAML parse, shell syntax, and `git diff --check`