### PR TITLE
fix(release): install binutils for musl CLI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,6 +397,7 @@ jobs:
             --volume "$PWD:/src" --workdir /src \
             python:3.12-alpine@sha256:285a71327884a4d50efbea30104473b0fa43ecefa499458899670ca30dae76e5 \
             sh -ec '
+              apk add --no-cache binutils
               python -m pip install --disable-pip-version-check pyinstaller==6.22.2 pyinstaller-hooks-contrib==2026.7
               python -m PyInstaller --noconfirm --clean --onefile \
                 --name rookhold-cli --paths sdks/python \

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -624,6 +624,7 @@ def check_pins_and_packaging() -> int:
         "--name rookhold-mcp",
         "Build musl-native standalone CLI and MCP apps",
         "python:3.12-alpine@sha256:285a71327884a4d50efbea30104473b0fa43ecefa499458899670ca30dae76e5",
+        "apk add --no-cache binutils",
         "Smoke standalone terminal apps without Python packaging",
         "Stage the direct single-file CLI download",
         "mcp-server",


### PR DESCRIPTION
The first consumer-ready v0.7.1 release attempt stopped before publication because PyInstaller correctly required objdump inside the pinned Alpine build container. Install Alpine binutils before the frozen musl build and keep that prerequisite enforced by the release-surface check. Windows and Apple-silicon standalone builds and MCP smoke tests already passed in the stopped run.