### PR TITLE
docs: distinguish hostile probes from harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,8 @@ development backend retains the service account's host networking and reports
 | `crates/coop-server` | API, fair scheduler, identity, observability, signer, dashboard, and OpenAPI |
 | `sdks` | Python and TypeScript clients |
 | `integrations` | MCP templates for Claude Code, OpenCode, Hermes, OpenClaw, and generic hosts |
-| `crates/coop-server/tests/hostile.rs` | adversarial containment probes |
+| `hostile-jobs` | adversarial payloads used by containment verification |
+| `crates/coop-server/tests/hostile.rs` | containment harness and invariant assertions |
 | `docs` | architecture, boundary, API, deployment, and operations |
 | `PRODUCT.md` | durable users, purpose, positioning, and product constraints |
 | `DESIGN.md` | operator-console tokens, responsive rules, and component language |


### PR DESCRIPTION
## Declared scope

Correct one repository-map row so future maintainers can distinguish tracked hostile payload fixtures from the Rust containment harness that executes and asserts them.

## Root invariant

Every maintained directory in the repository map must describe its actual role without hiding a separately important source path.

## Reproduction and RED evidence

Not applicable because this is a documentation correction. The final cleanup audit showed hostile-jobs contains nine tracked probe programs while crates/coop-server/tests/hostile.rs is the harness; the previous single-row wording conflated them.

## Changes

Document hostile-jobs as adversarial payloads and the Rust hostile test file as the containment harness and invariant assertions.

## Adversarial coverage

- [x] confirmed hostile-jobs files are tracked
- [x] confirmed the Rust hostile suite remains present
- [x] confirmed release-surface link and hostile-count checks pass

## Validation on final head

- Head: 7bfdf99
- Checks: release-surface validation and git diff whitespace checks pass on the final one-file diff; trusted CI is attached to this exact head.

## Non-goals and remaining work

No probe, harness, runtime, or release behavior changes. Branch and generated-file cleanup resumes after merge.

## Safety and compatibility

Documentation only; no API, isolation, evidence, storage, SDK, or release changes.

## Completion state

- Implementation: complete for the repository-map correction
- Validation: local exact-head checks complete; trusted CI running
- Review: pending maintainer approval
- Integration: pending protected merge and branch deletion