### PR TITLE
docs: report published release state accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ verifiable execution receipt.
 [![CI](https://github.com/sambai-dev/rookhold/actions/workflows/ci.yml/badge.svg)](https://github.com/sambai-dev/rookhold/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/sambai-dev/rookhold)](https://github.com/sambai-dev/rookhold/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![PyPI](https://img.shields.io/pypi/v/rookhold)](https://pypi.org/project/rookhold/)
-[![npm](https://img.shields.io/npm/v/rookhold)](https://www.npmjs.com/package/rookhold)
+
+> [!NOTE]
+> `rookhold run` and the `rookhold` registry packages are part of the upcoming
+> [v0.8.0](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0) release
+> and are available from `main` today. The current published release is
+> [v0.7.1](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1).
 
 ```console
 $ rookhold run python 'print(6 * 7)'
@@ -19,12 +23,17 @@ isolation    gvisor-application-kernel
 receipt      saved to .rookhold/runs/019…/receipt.json
 ```
 
-Install the SDK normally:
+Build the v0.8 SDKs from the current checkout:
 
 ```bash
-pip install rookhold
-npm install rookhold
+python -m pip install ./sdks/python
+cd sdks/typescript
+npm ci
+npm pack
 ```
+
+After v0.8.0 is published, those become `pip install rookhold` and
+`npm install rookhold`.
 
 ```python
 from rookhold import Rookhold
@@ -93,9 +102,9 @@ runs the MCP server for Claude Code, OpenCode, and other agent CLIs.
 
 | Your computer | Single-file CLI |
 |---|---|
-| Windows, 64-bit | [`rookhold-cli-x86_64-pc-windows-msvc.exe`](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-pc-windows-msvc.exe) |
-| Mac with Apple silicon | [`rookhold-cli-aarch64-apple-darwin`](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin) |
-| Linux x86_64 | [`rookhold-cli-x86_64-unknown-linux-gnu`](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu) |
+| Windows, 64-bit | [`rookhold-cli-x86_64-pc-windows-msvc.exe`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe) |
+| Mac with Apple silicon | [`rookhold-cli-aarch64-apple-darwin`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin) |
+| Linux x86_64 | [`rookhold-cli-x86_64-unknown-linux-gnu`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu) |
 
 Run it normally for the interactive CLI. Register the same path plus the
 `mcp-server` argument in an MCP host. On macOS or Linux, mark the download
@@ -115,14 +124,14 @@ source checkout.
 
 ### 1. Download the app
 
-Open the [v0.8.0 release](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0),
+Open the current [v0.7.1 release](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1),
 then choose the archive for your computer:
 
 | Your computer | Download the complete app bundle |
 |---|---|
-| Windows, 64-bit | [`rookhold-x86_64-pc-windows-msvc.zip`](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip) |
-| Mac with Apple silicon | [`rookhold-aarch64-apple-darwin.tar.gz`](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
-| Linux x86_64 | [`rookhold-x86_64-unknown-linux-musl.tar.gz`](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz) |
+| Windows, 64-bit | [`rookhold-x86_64-pc-windows-msvc.zip`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-pc-windows-msvc.zip) |
+| Mac with Apple silicon | [`rookhold-aarch64-apple-darwin.tar.gz`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-aarch64-apple-darwin.tar.gz) |
+| Linux x86_64 | [`rookhold-x86_64-unknown-linux-musl.tar.gz`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-unknown-linux-musl.tar.gz) |
 
 Extract the archive. It contains the Rookhold service, `rookhold-cli`,
 `rookhold-mcp`, verification tools, and the copy-ready agent configurations.
@@ -249,7 +258,8 @@ complete every deployment check.
 > accepting untrusted jobs.
 
 > [!NOTE]
-> **Current release:** [v0.8.0](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0).
+> **Current stable release:** [v0.7.1](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1).
+> The v0.8.0 source on `main` is validated but not yet tagged or published.
 > Its exact eleven-asset set includes checksums, a combined artifact-scoped SPDX
 > SBOM, GitHub SBOM/provenance attestations, and the offline `rookhold-verify`
 > verifier inside each platform archive. Older release lines are unsupported

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,21 +1,28 @@
 # Installation
 
-## Python
+The `rookhold` registry packages are prepared for v0.8.0 but are not public
+yet. Until the release is tagged, install from a checkout.
+
+## Python from a checkout
 
 ```bash
-python -m pip install rookhold
+python -m pip install ./sdks/python
 ```
 
-## TypeScript
+## TypeScript from a checkout
 
 ```bash
-npm install rookhold
+cd sdks/typescript
+npm ci
+npm pack
 ```
+
+After v0.8.0 publishes, use `pip install rookhold` or `npm install rookhold`.
 
 ## Command and service
 
-Download the archive for your operating system from the
-[v0.8.0 release](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0).
+The unified v0.8 archive is not public yet. The current stable archive is the
+[v0.7.1 release](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1).
 The archive contains `rookhold`, the MCP adapter, and the offline verifier.
 Verify `SHA256SUMS` and GitHub provenance before allowing an unsigned community
 binary to run.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,10 +1,17 @@
 # Quickstart
 
-Install the command from the [v0.8.0 release](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0), put `rookhold` on `PATH`, then run:
+The one-command flow is available on `main` and will ship in v0.8.0. Build the
+current checkout, then run:
 
 ```bash
+cargo build --locked -p coop-server --bin rookhold
+cp target/debug/rookhold ./rookhold
 rookhold run python 'print(6 * 7)'
 ```
+
+The current published release is
+[v0.7.1](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1) and still
+uses the explicit service-plus-client flow.
 
 Without configured service variables, the command manages a temporary
 loopback-only development service and prints an unavoidable warning:

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -2,7 +2,12 @@
 
 Rookhold ships small reference clients under `sdks/`. They intentionally mirror the HTTP API and are suitable for embedding in agent tool loops. The OpenAPI document remains the canonical contract for generated clients.
 
-The v0.8 release workflow tests SDK source, installs the built Python wheel and source distribution, packs the TypeScript client, and publishes the exact gated artifacts to PyPI and npm with GitHub trusted publishing. A final clean-environment job installs `rookhold==0.8.0` and `rookhold@0.8.0` from the public registries.
+The v0.8 release workflow is prepared to test SDK source, install the built
+Python wheel and source distribution, pack the TypeScript client, and publish
+the exact gated artifacts to PyPI and npm with GitHub trusted publishing. The
+registry packages are not public until v0.8.0 is tagged and that workflow
+finishes. A final clean-environment job will install `rookhold==0.8.0` and
+`rookhold@0.8.0` from the public registries.
 
 To install the v0.8.0 release, activate the intended Python virtual environment and download the exact release assets into an otherwise empty working directory. This example verifies both the checksum manifest and GitHub provenance before installation:
 

--- a/docs/use/cli.md
+++ b/docs/use/cli.md
@@ -1,5 +1,8 @@
 # CLI
 
+These unified commands are available from `main` and ship with v0.8.0. The
+current stable v0.7.1 archive uses `rookhold-cli` for client commands.
+
 ```bash
 rookhold run python 'print(6 * 7)'
 rookhold run python script.py --wall-seconds 2

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -4,11 +4,14 @@ A typed synchronous client and stdio MCP adapter with no required dependencies.
 Install the optional stream extra for a native WebSocket; otherwise `stream()`
 transparently uses cursor replay.
 
-Install from PyPI:
+Install from the current checkout:
 
 ```bash
-python -m pip install "rookhold[stream]"
+python -m pip install "./sdks/python[stream]"
 ```
+
+`python -m pip install "rookhold[stream]"` becomes available when v0.8.0 is
+published to PyPI.
 
 The common path is one call:
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -9,11 +9,15 @@ permissive CORS headers; a cross-origin frontend needs an explicitly
 allowlisted reverse-proxy policy, and its bearer key will be available to that
 frontend's JavaScript.
 
-Install from npm:
+Build and pack the current checkout:
 
 ```bash
-npm install rookhold
+cd sdks/typescript
+npm ci
+npm pack
 ```
+
+`npm install rookhold` becomes available when v0.8.0 is published to npm.
 
 The common path is one call:
 

--- a/templates/fastapi-code-runner/README.md
+++ b/templates/fastapi-code-runner/README.md
@@ -1,5 +1,9 @@
 # FastAPI code runner
 
+This starter targets the upcoming `rookhold==0.8.0` PyPI package. Until that
+package is public, install `../../sdks/python` from a Rookhold checkout before
+installing the remaining requirements.
+
 ```bash
 python -m venv .venv
 . .venv/bin/activate

--- a/templates/nextjs-code-runner/README.md
+++ b/templates/nextjs-code-runner/README.md
@@ -1,5 +1,8 @@
 # Next.js Rookhold starter
 
+This starter targets the upcoming `rookhold@0.8.0` npm package. Until that
+package is public, install the packed SDK from the Rookhold source checkout.
+
 ```bash
 npm install
 npm run dev


### PR DESCRIPTION
## Contribution tier

Tier A — documentation, examples, and integrations.

## Declared scope

Make the README and directly linked install pages report the actual public state: v0.7.1 is stable, while v0.8.0 and the registry packages are validated but not yet published.

## Changes

Remove broken PyPI/npm badges, point binary downloads to existing v0.7.1 assets, label v0.8.0 as upcoming, and provide truthful checkout-based SDK instructions until registry publication.

## Validation

`python scripts/check-release-surface.py`, VitePress production build, and `git diff --check` pass on commit 3c931cc.
