### PR TITLE
docs: launch public Vercel site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ __pycache__/
 
 # Local design-research workbench state is never part of the maintained source tree.
 /.impeccable/
+
+/.vercel/

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ Use Rookhold when an agent or user supplies short-lived code and you need it
 bounded, cancellable, and inspectable. It is not a persistent development
 workspace, browser sandbox, remote IDE, or general-purpose container platform.
 
-[Quickstart](https://sambai-dev.github.io/rookhold/getting-started/quickstart) ·
-[Python](https://sambai-dev.github.io/rookhold/use/python) ·
-[TypeScript](https://sambai-dev.github.io/rookhold/use/typescript) ·
-[CLI](https://sambai-dev.github.io/rookhold/use/cli) ·
-[MCP](https://sambai-dev.github.io/rookhold/use/mcp) ·
-[Recipes](https://sambai-dev.github.io/rookhold/use/recipes) ·
-[Self-hosting](https://sambai-dev.github.io/rookhold/deployment) ·
-[Security model](https://sambai-dev.github.io/rookhold/security-boundary) ·
-[API](https://sambai-dev.github.io/rookhold/api)
+[Quickstart](https://rookhold.vercel.app/getting-started/quickstart) ·
+[Python](https://rookhold.vercel.app/use/python) ·
+[TypeScript](https://rookhold.vercel.app/use/typescript) ·
+[CLI](https://rookhold.vercel.app/use/cli) ·
+[MCP](https://rookhold.vercel.app/use/mcp) ·
+[Recipes](https://rookhold.vercel.app/use/recipes) ·
+[Self-hosting](https://rookhold.vercel.app/deployment) ·
+[Security model](https://rookhold.vercel.app/security-boundary) ·
+[API](https://rookhold.vercel.app/api)
 
 > [!WARNING]
 > With no configured endpoint, `rookhold run` manages an unisolated local
@@ -335,7 +335,7 @@ The event chain remains server-verifiable operational evidence. A signed envelop
 
 ## Build from source (optional)
 
-Most users should use the [one-command quickstart](https://sambai-dev.github.io/rookhold/getting-started/quickstart).
+Most users should use the [one-command quickstart](https://rookhold.vercel.app/getting-started/quickstart).
 This section is only for contributors or operators who specifically want to
 compile Rookhold themselves. Install Rust 1.98 and the runtimes you intend to use:
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,19 +1,26 @@
 import { defineConfig } from "vitepress";
 
+const isVercel = process.env.VERCEL === "1";
+const siteBase = isVercel ? "/" : "/rookhold/";
+const siteOrigin = isVercel
+  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL ?? "rookhold.vercel.app"}`
+  : "https://sambai-dev.github.io/rookhold";
+
 export default defineConfig({
   title: "Rookhold Sandbox",
-  description: "Run short Python, Node, and Bash jobs with hard limits and verifiable receipts.",
+  description: "A controlled execution boundary for AI agents, with hard limits, live output, and verifiable receipts.",
   lang: "en-US",
-  base: "/rookhold/",
+  base: siteBase,
   cleanUrls: true,
   lastUpdated: true,
-  sitemap: { hostname: "https://sambai-dev.github.io/rookhold/" },
+  sitemap: { hostname: `${siteOrigin}/` },
   head: [
     ["meta", { name: "theme-color", content: "#12171e" }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:title", content: "Rookhold Sandbox" }],
-    ["meta", { property: "og:description", content: "Hard limits and a receipt for short untrusted code." }],
-    ["meta", { property: "og:image", content: "https://sambai-dev.github.io/rookhold/social-card.png" }],
+    ["meta", { property: "og:description", content: "Run agent code behind a boundary you control." }],
+    ["meta", { property: "og:image", content: `${siteOrigin}/social-card.png` }],
+    ["meta", { property: "og:url", content: `${siteOrigin}/` }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
   ],
   themeConfig: {
@@ -22,8 +29,10 @@ export default defineConfig({
     nav: [
       { text: "Start", link: "/getting-started/quickstart" },
       { text: "Use", link: "/use/cli" },
+      { text: "MCP", link: "/use/mcp" },
       { text: "Understand", link: "/understand/receipts" },
       { text: "Operate", link: "/deployment" },
+      { text: "Download v0.7.1", link: "https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1" },
     ],
     sidebar: {
       "/getting-started/": [

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -14,7 +14,7 @@
   --vp-button-alt-hover-text: #111827;
   --vp-button-alt-hover-bg: #f5f6f9;
   --vp-font-family-base: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  --vp-font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --vp-font-family-mono: "SFMono-Regular", consolas, "Liberation Mono", menlo, monospace;
 }
 
 html { scroll-behavior: smooth; }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,1 +1,142 @@
-:root{--vp-c-brand-1:#1e55e6;--vp-c-brand-2:#1647ca;--vp-c-brand-3:#123ba8;--vp-c-bg:#fdfeff;--vp-c-bg-soft:#f5f6f9;--vp-c-divider:#e1e4e9;--vp-c-text-1:#111827;--vp-c-text-2:#5e6675;--vp-font-family-base:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;--vp-font-family-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace}.VPNavBarTitle .title{font-weight:760;letter-spacing:-.02em}.VPHero .name{max-width:760px;color:#111827}.VPHero .text{max-width:800px;font-size:clamp(34px,5vw,64px);letter-spacing:-.045em;line-height:1.03}.VPHero .tagline{max-width:660px}.VPHero .image-bg{display:none}.VPFeature{border-radius:4px!important;border-color:#d8dde5!important}.vp-doc div[class*=language-]{border-radius:4px}.receipt-demo{margin:28px 0;padding:18px 20px;background:#12171e;color:#e7ebf1;border-left:4px solid #79a0ff;font:13px/1.7 var(--vp-font-family-mono)}.receipt-demo strong{color:#79a0ff}.truth-warning{border-left:3px solid #a76400;padding:10px 14px;background:#fff8e8;color:#704600}@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;transition:none!important}}
+:root {
+  --vp-c-brand-1: #1e55e6;
+  --vp-c-brand-2: #1647ca;
+  --vp-c-brand-3: #123ba8;
+  --vp-c-bg: #fdfeff;
+  --vp-c-bg-soft: #f5f6f9;
+  --vp-c-divider: #e1e4e9;
+  --vp-c-text-1: #111827;
+  --vp-c-text-2: #5e6675;
+  --vp-button-alt-border: #c8cdd6;
+  --vp-button-alt-text: #111827;
+  --vp-button-alt-bg: #ffffff;
+  --vp-button-alt-hover-border: #9ca3af;
+  --vp-button-alt-hover-text: #111827;
+  --vp-button-alt-hover-bg: #f5f6f9;
+  --vp-font-family-base: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --vp-font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+html { scroll-behavior: smooth; }
+.VPNavBarTitle .title { font-weight: 760; letter-spacing: -.02em; }
+.VPNavBar { border-bottom: 1px solid var(--vp-c-divider); }
+.VPHero { padding-top: 88px !important; padding-bottom: 54px !important; }
+.VPHero .name { max-width: 760px; color: #1e55e6; font-size: 18px; letter-spacing: -.01em; }
+.VPHero .text { max-width: 900px; font-size: clamp(42px, 6vw, 76px); letter-spacing: -.055em; line-height: .98; text-wrap: balance; }
+.VPHero .tagline { max-width: 720px; font-size: clamp(17px, 2vw, 21px); line-height: 1.55; }
+.VPHero .image-bg { display: none; }
+.VPHero .actions { padding-top: 10px; }
+.VPButton { border-radius: 4px !important; min-height: 44px; padding-inline: 20px !important; }
+.VPButton.alt { background: #fff !important; border-color: #c8cdd6 !important; color: #111827 !important; }
+.VPButton.alt:hover { background: #f5f6f9 !important; border-color: #9ca3af !important; }
+.VPFeatures { padding-bottom: 56px !important; }
+.VPFeature { border-radius: 0 !important; border-color: #d8dde5 !important; }
+.VPFeature .title { font-size: 15px; }
+.vp-doc div[class*=language-] { border-radius: 4px; }
+.VPHome .VPContent { overflow: hidden; }
+.VPHome .vp-doc.container { max-width: none; padding: 0; }
+.VPHome .vp-doc > section { max-width: 1152px; margin-inline: auto; padding-inline: 24px; }
+.VPHome .vp-doc h2 { margin: 0; border: 0; font-size: clamp(30px, 4vw, 48px); line-height: 1.06; letter-spacing: -.04em; text-wrap: balance; }
+.VPHome .vp-doc p { color: #5e6675; }
+.section-kicker { margin: 0 0 14px !important; color: #1e55e6 !important; font: 700 11px/1.4 var(--vp-font-family-mono); letter-spacing: .12em; }
+.section-heading { max-width: 700px; }
+.section-heading > p:last-child { max-width: 650px; margin-top: 18px; font-size: 17px; line-height: 1.65; }
+
+.home-proof { display: grid; grid-template-columns: repeat(3, 1fr); padding-block: 0 78px; }
+.home-proof p { display: flex; flex-direction: column; gap: 7px; margin: 0; padding: 18px 20px; border: 1px solid #e1e4e9; border-right: 0; }
+.home-proof p:last-child { border-right: 1px solid #e1e4e9; }
+.home-proof strong { color: #5e6675; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.home-proof span { color: #111827; font: 600 13px/1.4 var(--vp-font-family-mono); }
+
+.home-demo { display: grid; grid-template-columns: .85fr 1.35fr; align-items: stretch; padding-bottom: 96px; }
+.home-demo-copy { padding: 52px 50px 52px 0; }
+.home-demo-copy > p:not(.section-kicker) { max-width: 510px; margin-top: 20px; font-size: 17px; line-height: 1.65; }
+.home-demo-actions { display: flex; flex-wrap: wrap; gap: 22px; margin-top: 28px; }
+.home-text-link { color: #1e55e6 !important; font-weight: 650; text-decoration: none !important; }
+.home-text-link:hover { text-decoration: underline !important; text-underline-offset: 4px; }
+.terminal-stage { min-width: 0; background: #12171e; color: #e7ebf1; border: 1px solid #29323e; font: 12px/1.55 var(--vp-font-family-mono); }
+.terminal-head { display: flex; justify-content: space-between; padding: 13px 16px; color: #9da7b5; border-bottom: 1px solid #29323e; }
+.terminal-head span:last-child { color: #7dd89b; }
+.terminal-line { display: flex; gap: 14px; padding: 26px 22px; color: #f7f9fc; border-bottom: 1px solid #29323e; font-size: 13px; }
+.terminal-line .prompt { color: #79a0ff; }
+.terminal-event { display: grid; grid-template-columns: 42px 150px 1fr; gap: 10px; padding: 19px 22px; border-bottom: 1px solid #29323e; }
+.terminal-event > span:first-child { color: #79a0ff; }
+.terminal-event strong { color: #e7ebf1; font-weight: 600; }
+.terminal-event > span:last-child { color: #9da7b5; }
+.terminal-receipt { display: grid; grid-template-columns: 70px 1fr auto; gap: 12px; align-items: center; padding: 19px 22px; background: #171d25; }
+.terminal-receipt > span { color: #9da7b5; }
+.terminal-receipt code { min-width: 0; overflow: hidden; color: #e7ebf1; text-overflow: ellipsis; white-space: nowrap; }
+.terminal-receipt b { color: #7dd89b; font-weight: 650; }
+
+.download-section { padding-block: 96px !important; border-block: 1px solid #e1e4e9; }
+.download-grid { display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 42px; border: 1px solid #c8cdd6; }
+.download-option { display: flex; flex-direction: column; gap: 5px; min-height: 158px; padding: 24px; color: #111827 !important; border-right: 1px solid #c8cdd6; text-decoration: none !important; transition: background-color 150ms ease, color 150ms ease; }
+.download-option:last-child { border-right: 0; }
+.download-option:hover { background: #1e55e6; color: #fff !important; }
+.download-os { margin-bottom: auto; color: #5e6675; font: 700 11px/1.4 var(--vp-font-family-mono); letter-spacing: .1em; text-transform: uppercase; }
+.download-option:hover .download-os, .download-option:hover small { color: #dce6ff; }
+.download-option strong { font-size: 20px; letter-spacing: -.02em; }
+.download-option small { color: #7a8392; font: 12px/1.4 var(--vp-font-family-mono); }
+.download-footnote { margin-top: 18px; font-size: 13px; }
+
+.mcp-section { padding-block: 96px !important; }
+.mcp-layout { display: grid; grid-template-columns: 1.15fr 1fr; gap: 48px; align-items: center; margin-top: 46px; }
+.mcp-code { background: #12171e; color: #e7ebf1; border: 1px solid #29323e; }
+.mcp-code-head { display: flex; justify-content: space-between; padding: 12px 16px; color: #9da7b5; border-bottom: 1px solid #29323e; font: 11px/1.4 var(--vp-font-family-mono); }
+.mcp-code pre { margin: 0; padding: 24px; overflow: auto; background: transparent; font-size: 13px; line-height: 1.7; }
+.mcp-code code { color: #e7ebf1; }
+.mcp-steps { margin: 0 !important; padding: 0 !important; list-style: none; }
+.mcp-steps li { display: grid; grid-template-columns: 38px 1fr; gap: 16px; padding: 19px 0; border-bottom: 1px solid #e1e4e9; }
+.mcp-steps li:first-child { border-top: 1px solid #e1e4e9; }
+.mcp-steps li > span { color: #1e55e6; font: 700 12px/1.4 var(--vp-font-family-mono); }
+.mcp-steps strong { color: #111827; font-size: 15px; }
+.mcp-steps p { margin: 5px 0 0; line-height: 1.55; }
+.host-links { display: flex; flex-wrap: wrap; gap: 0; margin-top: 32px; border: 1px solid #e1e4e9; }
+.host-links a { flex: 1 1 150px; padding: 14px 18px; color: #111827; border-right: 1px solid #e1e4e9; text-align: center; text-decoration: none; }
+.host-links a:last-child { border-right: 0; }
+.host-links a:hover { color: #1e55e6; background: #f5f6f9; }
+
+.boundary-section { display: grid; grid-template-columns: 1fr 1fr; gap: 70px; max-width: none !important; padding: 92px max(24px, calc((100vw - 1104px) / 2)) !important; background: #12171e; color: #e7ebf1; }
+.boundary-section .section-kicker { color: #79a0ff !important; }
+.boundary-section h2 { color: #f7f9fc; }
+.boundary-copy p { margin: 0 0 18px; color: #b4bdc9 !important; font-size: 16px; line-height: 1.65; }
+.boundary-copy code { color: #e7ebf1; background: #1b222c; }
+.boundary-copy .home-text-link { color: #79a0ff !important; }
+
+.faq-section { display: grid; grid-template-columns: .72fr 1.28fr; gap: 72px; padding-block: 96px !important; }
+.faq-list { border-top: 1px solid #c8cdd6; }
+.faq-list details { border-bottom: 1px solid #c8cdd6; }
+.faq-list summary { padding: 20px 34px 20px 0; color: #111827; font-weight: 650; cursor: pointer; }
+.faq-list details p { margin: -4px 0 20px; max-width: 660px; line-height: 1.65; }
+
+.final-cta { max-width: none !important; padding: 94px max(24px, calc((100vw - 1104px) / 2)) 104px !important; background: #edf2ff; text-align: center; }
+.final-cta h2 { max-width: 760px; margin-inline: auto !important; }
+.final-cta a { display: inline-flex; gap: 16px; align-items: center; min-height: 48px; margin-top: 30px; padding: 0 20px; background: #1e55e6; color: #fff; border-radius: 4px; font-weight: 650; text-decoration: none; }
+.final-cta a:hover { background: #1647ca; }
+
+@media (max-width: 820px) {
+  .VPHero { padding-top: 60px !important; }
+  .home-proof { grid-template-columns: 1fr; }
+  .home-proof p, .home-proof p:last-child { border: 1px solid #e1e4e9; border-bottom: 0; }
+  .home-proof p:last-child { border-bottom: 1px solid #e1e4e9; }
+  .home-demo, .mcp-layout, .boundary-section, .faq-section { grid-template-columns: 1fr; gap: 36px; }
+  .home-demo-copy { padding: 0; }
+  .download-grid { grid-template-columns: 1fr; }
+  .download-option, .download-option:last-child { min-height: 132px; border-right: 0; border-bottom: 1px solid #c8cdd6; }
+  .download-option:last-child { border-bottom: 0; }
+  .boundary-section { padding-block: 72px !important; }
+}
+
+@media (max-width: 520px) {
+  .VPHero .text { font-size: 42px; }
+  .VPHome .vp-doc > section { padding-inline: 18px; }
+  .terminal-event { grid-template-columns: 32px 1fr; }
+  .terminal-event > span:last-child { grid-column: 2; }
+  .terminal-receipt { grid-template-columns: 1fr auto; }
+  .terminal-receipt code { grid-column: 1 / -1; grid-row: 2; }
+  .boundary-section, .final-cta { padding-inline: 18px !important; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { scroll-behavior: auto !important; transition: none !important; }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,29 +1,131 @@
 ---
 layout: home
 title: Rookhold Sandbox
-titleTemplate: Short jobs with hard limits and receipts
+titleTemplate: Controlled code execution for AI agents
+description: Download the Rookhold CLI and connect Claude Code, OpenCode, Hermes, or another MCP host to a controlled execution service.
 
 hero:
-  name: Rookhold Sandbox
-  text: Run code. Keep the boundary.
-  tagline: Short Python, Node, and Bash jobs with hard limits, live output, and a receipt that records what happened.
+  name: Rookhold
+  text: Run agent code behind a boundary you control.
+  tagline: One downloadable CLI connects your app or agent to short Python, Node, and Bash jobs with hard limits, bounded live output, and a verifiable receipt.
   actions:
     - theme: brand
-      text: Run the quickstart
-      link: /getting-started/quickstart
+      text: Download the CLI
+      link: '#download'
     - theme: alt
-      text: Read the receipt model
-      link: /understand/receipts
+      text: Connect an MCP host
+      link: /use/mcp
 
 features:
-  - title: One command
-    details: Run a trusted local example immediately, or point the same command at a separately operated Linux service.
-  - title: Limits that end jobs
-    details: Wall time, CPU, memory, process, file, and output bounds are recorded as requested and actually enforced.
-  - title: One receipt per run
-    details: Keep the outcome, output hashes, event-chain head, runtime digest, isolation, and requested file hashes together.
+  - title: One consumer file
+    details: Download rookhold-cli for Windows, macOS, or Linux. No Python, Node, Rust, or source checkout is required.
+  - title: CLI and MCP together
+    details: Use the terminal directly, or launch the same file with mcp-server from Claude Code, OpenCode, Hermes, and other MCP hosts.
+  - title: Evidence after every run
+    details: Limits, output hashes, runtime facts, isolation, completion state, and the event-chain head stay with the result.
 ---
 
-<div class="receipt-demo"><strong>$ rookhold run python</strong> 'print(6 * 7)'<br>42<br><br>status&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; succeeded<br>network&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; disabled<br>isolation&nbsp;&nbsp;&nbsp; gvisor-application-kernel<br>receipt&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; saved to .rookhold/runs/…/receipt.json</div>
+<section class="home-proof" aria-label="Release facts">
+  <p><strong>Current stable</strong><span>v0.7.1</span></p>
+  <p><strong>Agent interface</strong><span>MCP over stdio</span></p>
+  <p><strong>Production boundary</strong><span>gVisor on Linux x86_64</span></p>
+</section>
 
-<p class="truth-warning"><strong>Local development is not containment.</strong> On macOS, Windows, and an unisolated Linux setup, Rookhold reports <code>isolation: none</code>. Use a dedicated Linux gVisor service for untrusted code.</p>
+<section class="home-demo" aria-labelledby="demo-heading">
+  <div class="home-demo-copy">
+    <p class="section-kicker">ONE FILE · TWO INTERFACES</p>
+    <h2 id="demo-heading">Use it yourself. Or give it to your agent.</h2>
+    <p>The normal command opens Rookhold's operator CLI. The <code>mcp-server</code> argument turns that same executable into a concurrent stdio MCP server with four narrow execution tools.</p>
+    <div class="home-demo-actions">
+      <a class="home-text-link" href="./use/cli">Open the CLI guide <span aria-hidden="true">→</span></a>
+      <a class="home-text-link" href="./use/mcp">Open the MCP guide <span aria-hidden="true">→</span></a>
+    </div>
+  </div>
+  <div class="terminal-stage" role="img" aria-label="Rookhold CLI showing a successful bounded Python job and saved receipt">
+    <div class="terminal-head"><span>rookhold-cli</span><span>connected · gvisor</span></div>
+    <div class="terminal-line"><span class="prompt">›</span><span>/run python "print(6 * 7)"</span></div>
+    <div class="terminal-event"><span>01</span><strong>policy accepted</strong><span>network disabled · 2s wall</span></div>
+    <div class="terminal-event"><span>02</span><strong>job completed</strong><span>42</span></div>
+    <div class="terminal-receipt"><span>receipt</span><code>.rookhold/runs/…/receipt.json</code><b>succeeded</b></div>
+  </div>
+</section>
+
+<section id="download" class="download-section" aria-labelledby="download-heading">
+  <div class="section-heading">
+    <p class="section-kicker">DOWNLOAD v0.7.1</p>
+    <h2 id="download-heading">Pick your operating system.</h2>
+    <p>Each link is a single standalone CLI file from the immutable GitHub release. Keep it at a stable path; agent hosts launch the same file with <code>mcp-server</code>.</p>
+  </div>
+  <div class="download-grid">
+    <a class="download-option" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe">
+      <span class="download-os">Windows</span><strong>Download .exe</strong><small>x86_64 · 9.1 MB</small>
+    </a>
+    <a class="download-option" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin">
+      <span class="download-os">macOS</span><strong>Download binary</strong><small>Apple Silicon · 8.2 MB</small>
+    </a>
+    <a class="download-option" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu">
+      <span class="download-os">Linux</span><strong>Download binary</strong><small>x86_64 GNU · 21.0 MB</small>
+    </a>
+  </div>
+  <p class="download-footnote">Need the server, verifier, SDKs, checksums, or another platform? <a href="https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1">View every release asset</a>.</p>
+</section>
+
+<section class="mcp-section" aria-labelledby="mcp-heading">
+  <div class="section-heading">
+    <p class="section-kicker">AGENT INTEGRATION</p>
+    <h2 id="mcp-heading">Connect any local MCP host.</h2>
+    <p>Rookhold keeps the endpoint, credential, allowed languages, and minimum isolation outside the model's tool arguments.</p>
+  </div>
+  <div class="mcp-layout">
+    <div class="mcp-code" aria-label="Generic MCP configuration example">
+      <div class="mcp-code-head"><span>mcp.json</span><span>stdio</span></div>
+      <pre><code>{
+  "mcpServers": {
+    "rookhold": {
+      "command": "rookhold-cli",
+      "args": ["mcp-server"]
+    }
+  }
+}</code></pre>
+    </div>
+    <ol class="mcp-steps">
+      <li><span>01</span><div><strong>Download one file</strong><p>Put <code>rookhold-cli</code> on PATH or use its absolute path.</p></div></li>
+      <li><span>02</span><div><strong>Set operator policy</strong><p>Export the endpoint, scoped key, language allowlist, and required isolation class.</p></div></li>
+      <li><span>03</span><div><strong>Register and check</strong><p>Launch <code>mcp-server</code>, then confirm the four live Rookhold tools in your host.</p></div></li>
+    </ol>
+  </div>
+  <div class="host-links" aria-label="Supported host guides">
+    <a href="https://github.com/sambai-dev/rookhold/blob/main/integrations/claude-code/mcp.json">Claude Code</a>
+    <a href="https://github.com/sambai-dev/rookhold/blob/main/integrations/opencode/opencode.snippet.json">OpenCode</a>
+    <a href="https://github.com/sambai-dev/rookhold/blob/main/integrations/hermes/config.snippet.yaml">Hermes</a>
+    <a href="./use/mcp">Generic MCP</a>
+  </div>
+</section>
+
+<section class="boundary-section" aria-labelledby="boundary-heading">
+  <div>
+    <p class="section-kicker">THE SECURITY BOUNDARY</p>
+    <h2 id="boundary-heading">The website is hosted. The executor is yours.</h2>
+  </div>
+  <div class="boundary-copy">
+    <p>Vercel serves these public docs and downloads. It does not run Rookhold's privileged execution backend.</p>
+    <p>For untrusted code, operate Rookhold on a dedicated Linux x86_64 host with the pinned gVisor provider. Local development on Windows, macOS, or an unisolated Linux setup reports <code>isolation: none</code>.</p>
+    <a class="home-text-link" href="./getting-started/first-secure-deployment">Build the secure boundary <span aria-hidden="true">→</span></a>
+  </div>
+</section>
+
+<section class="faq-section" aria-labelledby="faq-heading">
+  <div class="section-heading"><p class="section-kicker">BEFORE YOU START</p><h2 id="faq-heading">The short answers.</h2></div>
+  <div class="faq-list">
+    <details><summary>Does the CLI include the sandbox service?</summary><p>The full release archive includes the service and verifier. The one-file CLI is the consumer interface and connects to a separately operated Rookhold endpoint.</p></details>
+    <details><summary>Does MCP replace Claude Code or OpenCode?</summary><p>No. Your existing host owns the conversation and model. Rookhold adds four execution tools with policy and evidence.</p></details>
+    <details><summary>Does adding Rookhold disable the host's shell?</summary><p>No. Remove or deny alternate shell and code-execution tools when the model must cross only the Rookhold boundary.</p></details>
+    <details><summary>Can I safely run untrusted code on my laptop?</summary><p>No. The local demo is explicitly unisolated. Use the dedicated Linux gVisor deployment for the production boundary.</p></details>
+  </div>
+</section>
+
+<section class="final-cta" aria-label="Download Rookhold">
+  <p class="section-kicker">SHORT JOBS · HARD LIMITS · RECEIPTS</p>
+  <h2>Give your agent a controlled place to run code.</h2>
+  <a href="#download">Download Rookhold v0.7.1 <span aria-hidden="true">↓</span></a>
+</section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ features:
     <h2 id="boundary-heading">The website is hosted. The executor is yours.</h2>
   </div>
   <div class="boundary-copy">
-    <p>Vercel serves these public docs and downloads. It does not run Rookhold's privileged execution backend.</p>
+    <p>Vercel serves these public docs. Download links point directly to immutable GitHub Releases assets. Vercel does not run Rookhold's privileged execution backend.</p>
     <p>For untrusted code, operate Rookhold on a dedicated Linux x86_64 host with the pinned gVisor provider. Local development on Windows, macOS, or an unisolated Linux setup reports <code>isolation: none</code>.</p>
     <a class="home-text-link" href="./getting-started/first-secure-deployment">Build the secure boundary <span aria-hidden="true">→</span></a>
   </div>

--- a/docs/use/mcp.md
+++ b/docs/use/mcp.md
@@ -1,6 +1,43 @@
 # MCP
 
-Configure one of the maintained hosts:
+The same standalone `rookhold-cli` file used by a human can serve MCP over
+stdio. Your host launches it with one argument:
+
+```text
+rookhold-cli mcp-server
+```
+
+The adapter exposes four tools:
+
+| Tool | What it does |
+|---|---|
+| `rookhold_run_code` | Submit one short job and wait for bounded output plus its receipt |
+| `rookhold_job_result` | Resume a wait or take an immediate job snapshot |
+| `rookhold_job_events` | Read a bounded cursor page of persisted evidence |
+| `rookhold_cancel_job` | Cancel a queued or running job |
+
+The model cannot choose the Rookhold URL, bearer key, language allowlist,
+maximum code size, maximum wait, or minimum isolation. Configure those as
+process environment variables:
+
+```bash
+export ROOKHOLD_BASE_URL=https://rookhold.internal.example
+export ROOKHOLD_API_KEY=replace-with-a-scoped-key
+export ROOKHOLD_MCP_MINIMUM_ISOLATION=gvisor-application-kernel
+export ROOKHOLD_MCP_ALLOWED_LANGUAGES=python,node
+```
+
+For the current stable v0.7.1 executable, merge one of the maintained host
+templates and point its command at the downloaded file:
+
+- [Claude Code template](https://github.com/sambai-dev/rookhold/blob/main/integrations/claude-code/mcp.json)
+- [OpenCode template](https://github.com/sambai-dev/rookhold/blob/main/integrations/opencode/opencode.snippet.json)
+- [Hermes template](https://github.com/sambai-dev/rookhold/blob/main/integrations/hermes/config.snippet.yaml)
+- [OpenClaw template](https://github.com/sambai-dev/rookhold/blob/main/integrations/openclaw/openclaw.snippet.json5)
+- [Generic MCP configuration](https://github.com/sambai-dev/rookhold/blob/main/integrations/README.md#generic-mcp-host)
+
+After v0.8.0 is released, the unified command can configure a maintained host
+for you:
 
 ```bash
 rookhold setup claude-code
@@ -14,3 +51,23 @@ environment, and runs `rookhold check` afterward.
 
 Adding Rookhold does not disable a host's built-in shell. Remove or deny other
 execution tools when a model must cross only the Rookhold boundary.
+
+## Verify the connection
+
+1. Start the host with the four `ROOKHOLD_*` values in its environment.
+2. Open its MCP status surface and confirm the `rookhold` server is connected.
+3. Confirm exactly four Rookhold tools are advertised.
+4. Submit a trusted canary and inspect its result, isolation, and receipt.
+
+Claude Code users can run `claude mcp list`, `claude mcp get rookhold`, and
+then `/mcp`. OpenCode, Hermes, and other hosts expose an equivalent MCP status
+or reload surface.
+
+::: warning Rookhold is not automatically mandatory
+Adding the MCP server does not disable a host's built-in shell, terminal, or
+other execution routes. Remove or deny those tools when a model must cross
+only the Rookhold boundary.
+:::
+
+See the [complete integration contract](https://github.com/sambai-dev/rookhold/tree/main/integrations)
+for timeout, retry, Tasks, and host-specific policy details.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
 stream = ["websocket-client>=1.6,<2"]
 
 [project.urls]
-Homepage = "https://sambai-dev.github.io/rookhold/"
+Homepage = "https://rookhold.vercel.app/"
 Repository = "https://github.com/sambai-dev/rookhold"
 Issues = "https://github.com/sambai-dev/rookhold/issues"
 

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -51,7 +51,7 @@
     "directory": "sdks/typescript"
   },
   "bugs": "https://github.com/sambai-dev/rookhold/issues",
-  "homepage": "https://sambai-dev.github.io/rookhold/",
+  "homepage": "https://rookhold.vercel.app/",
   "devDependencies": {
     "typescript": "^7.0.2"
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm --prefix docs run docs:build",
+  "installCommand": "npm --prefix docs ci",
+  "outputDirectory": "docs/.vitepress/dist",
+  "framework": null,
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Contribution tier

Tier C — public deployment, canonical documentation metadata, and consumer onboarding surface.

## Declared scope

Publish Rookhold's existing VitePress documentation as a consumer-friendly Vercel site, make stable CLI downloads and MCP onboarding prominent, and update canonical repository/package links to the new public domain.

## Root invariant

The public website must never imply that Vercel hosts Rookhold's privileged execution boundary. Stable v0.7.1 instructions, unreleased v0.8 workflow, local unisolated development, and the dedicated Linux gVisor production boundary remain explicitly distinct.

## Reproduction and RED evidence

RED: repository and SDK metadata sent users to the GitHub Pages URL reported as inaccessible. The previous docs home failed to provide direct per-platform CLI downloads, while the MCP page omitted the four-tool contract, operator-owned environment policy, stable-vs-next setup split, and host-bypass warning.

## Changes

- add a root Vercel static-build contract with security headers
- make the VitePress base and canonical metadata deployment-aware while retaining GitHub Pages compatibility
- rebuild the home page around one-file CLI downloads, CLI/MCP onboarding, honest boundary language, responsive FAQ, and the existing Chalk-and-Carbon system
- expand the MCP guide with the exact four tools, environment-owned policy, maintained host templates, verification steps, and bypass warning
- move README and Python/TypeScript package homepages to https://rookhold.vercel.app
- ignore only local Vercel linkage state and continue excluding environment files through the existing patterns

## Adversarial coverage

- [x] 390px production layout has no horizontal overflow and exposes mobile navigation
- [x] production MCP page advertises exactly the four maintained tool names
- [x] MCP guide warns that registration does not disable alternate host execution routes
- [x] hosted/executor boundary and stable v0.7.1 versus unreleased v0.8 copy remain distinct
- [x] both Vercel-root and GitHub Pages subpath builds pass

## Validation

- Head: b602720f76481ffd59937f28b22c00ffd2f4ecd4
- Checks: release-surface contract; 29 MCP tests; 12 CLI tests; Vercel-root docs build; GitHub Pages subpath build; JSON parsing; whitespace check; desktop and 390px production browser verification with no console warnings/errors; Vercel Ready deployment and HTTP 200 security-header check.

## Non-goals and remaining work

The privileged gVisor service is not deployed to Vercel. Operators still deploy the Rookhold execution backend on a dedicated Linux x86_64 host. The v0.8 unified CLI/setup flow remains unreleased and is labeled accordingly.

## Safety and compatibility

No credential is committed or exposed to the model. Vercel serves only static documentation. Existing GitHub Pages deployment remains build-compatible through the default /rookhold/ base, while Vercel uses /. All download links target the immutable v0.7.1 release assets.

## Completion state

- Implementation: complete
- Validation: complete
- Review: complete; CI is green and both CodeRabbit findings are addressed
- Integration: complete; merged as bd46c9d and the main Vercel deployment is Ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned documentation homepage with release details, downloads, MCP integration guidance, security information, FAQ, and calls to action.
  * Added MCP setup instructions, supported tools, configuration options, host templates, and connection verification steps.
  * Added navigation links for MCP documentation and the v0.7.1 download.

* **Improvements**
  * Improved responsive styling across desktop, tablet, and mobile layouts.
  * Updated documentation and package links to the new hosted site.
  * Added deployment configuration and security headers for the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


