### PR TITLE
docs: tighten desktop layout and identity

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,17 +7,19 @@ const siteOrigin = isVercel
   : "https://sambai-dev.github.io/rookhold";
 
 export default defineConfig({
-  title: "Rookhold Sandbox",
+  title: "Rookhold",
   description: "A controlled execution boundary for AI agents, with hard limits, live output, and verifiable receipts.",
   lang: "en-US",
   base: siteBase,
   cleanUrls: true,
   lastUpdated: true,
+  appearance: false,
   sitemap: { hostname: `${siteOrigin}/` },
   head: [
     ["meta", { name: "theme-color", content: "#12171e" }],
+    ["link", { rel: "icon", type: "image/svg+xml", href: `${siteBase}rook.svg` }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:title", content: "Rookhold Sandbox" }],
+    ["meta", { property: "og:title", content: "Rookhold" }],
     ["meta", { property: "og:description", content: "Run agent code behind a boundary you control." }],
     ["meta", { property: "og:image", content: `${siteOrigin}/social-card.png` }],
     ["meta", { property: "og:url", content: `${siteOrigin}/` }],
@@ -27,11 +29,11 @@ export default defineConfig({
     logo: "/rook.svg",
     search: { provider: "local" },
     nav: [
-      { text: "Start", link: "/getting-started/quickstart" },
-      { text: "Use", link: "/use/cli" },
+      { text: "Get started", link: "/getting-started/quickstart" },
+      { text: "CLI", link: "/use/cli" },
       { text: "MCP", link: "/use/mcp" },
-      { text: "Understand", link: "/understand/receipts" },
-      { text: "Operate", link: "/deployment" },
+      { text: "Security", link: "/security-boundary" },
+      { text: "Deploy", link: "/deployment" },
       { text: "Download v0.7.1", link: "https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1" },
     ],
     sidebar: {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -9,7 +9,7 @@
   --vp-c-text-2: #5e6675;
   --vp-button-alt-border: #c8cdd6;
   --vp-button-alt-text: #111827;
-  --vp-button-alt-bg: #ffffff;
+  --vp-button-alt-bg: #fff;
   --vp-button-alt-hover-border: #9ca3af;
   --vp-button-alt-hover-text: #111827;
   --vp-button-alt-hover-bg: #f5f6f9;
@@ -18,123 +18,211 @@
 }
 
 html { scroll-behavior: smooth; }
+body { background: #fdfeff; }
+::selection { background: #dce6ff; color: #111827; }
+:focus-visible { outline: 3px solid #1e55e6; outline-offset: 3px; }
+* { scrollbar-color: #9da7b5 #f5f6f9; }
+
+.VPNavBar { border-bottom: 1px solid #e1e4e9; }
 .VPNavBarTitle .title { font-weight: 760; letter-spacing: -.02em; }
-.VPNavBar { border-bottom: 1px solid var(--vp-c-divider); }
-.VPHero { padding-top: 88px !important; padding-bottom: 54px !important; }
-.VPHero .name { max-width: 760px; color: #1e55e6; font-size: 18px; letter-spacing: -.01em; }
-.VPHero .text { max-width: 900px; font-size: clamp(42px, 6vw, 76px); letter-spacing: -.055em; line-height: .98; text-wrap: balance; }
-.VPHero .tagline { max-width: 720px; font-size: clamp(17px, 2vw, 21px); line-height: 1.55; }
-.VPHero .image-bg { display: none; }
+.VPNavBarTitle .logo { width: 28px; height: 28px; }
+.DocSearch-Button {
+  background: #fff !important;
+  border: 1px solid #e1e4e9 !important;
+  color: #5e6675 !important;
+}
+.DocSearch-Button:hover { border-color: #c8cdd6 !important; }
+
+.VPHero { padding: 82px 24px 64px !important; }
+.VPHero .container { max-width: 1152px !important; }
+.VPHero .main { max-width: 700px; }
+.VPHero .text {
+  max-width: 700px;
+  font-size: clamp(42px, 5.2vw, 68px);
+  line-height: 1.01;
+  letter-spacing: -.04em;
+  text-wrap: balance;
+}
+.VPHero .tagline {
+  max-width: 660px;
+  font-size: clamp(17px, 1.6vw, 20px);
+  line-height: 1.55;
+  text-wrap: pretty;
+}
 .VPHero .actions { padding-top: 10px; }
-.VPButton { border-radius: 4px !important; min-height: 44px; padding-inline: 20px !important; }
+.VPHero .image { display: flex; align-items: center; justify-content: flex-end; }
+.VPHero .image-container { width: 260px; height: 260px; transform: none; }
+.VPHero .image-src { width: 260px; height: 260px; max-width: none; max-height: none; }
+.VPHero .image-bg { display: none; }
+.VPButton { min-height: 44px; padding-inline: 20px !important; border-radius: 4px !important; }
 .VPButton.alt { background: #fff !important; border-color: #c8cdd6 !important; color: #111827 !important; }
 .VPButton.alt:hover { background: #f5f6f9 !important; border-color: #9ca3af !important; }
-.VPFeatures { padding-bottom: 56px !important; }
-.VPFeature { border-radius: 0 !important; border-color: #d8dde5 !important; }
-.VPFeature .title { font-size: 15px; }
+
 .vp-doc div[class*=language-] { border-radius: 4px; }
 .VPHome .VPContent { overflow: hidden; }
 .VPHome .vp-doc.container { max-width: none; padding: 0; }
-.VPHome .vp-doc > section { max-width: 1152px; margin-inline: auto; padding-inline: 24px; }
-.VPHome .vp-doc h2 { margin: 0; border: 0; font-size: clamp(30px, 4vw, 48px); line-height: 1.06; letter-spacing: -.04em; text-wrap: balance; }
-.VPHome .vp-doc p { color: #5e6675; }
-.section-kicker { margin: 0 0 14px !important; color: #1e55e6 !important; font: 700 11px/1.4 var(--vp-font-family-mono); letter-spacing: .12em; }
+.VPHome section:not(.boundary-section):not(.final-cta) {
+  width: 100%;
+  max-width: 1152px;
+  margin-inline: auto;
+  padding-inline: 24px;
+}
+.VPHome section h2 {
+  margin: 0;
+  border: 0;
+  font-size: clamp(30px, 3.2vw, 46px);
+  line-height: 1.08;
+  letter-spacing: -.035em;
+  text-wrap: balance;
+}
+.VPHome section p { color: #5e6675; text-wrap: pretty; }
 .section-heading { max-width: 700px; }
-.section-heading > p:last-child { max-width: 650px; margin-top: 18px; font-size: 17px; line-height: 1.65; }
+.section-heading > p:last-child { max-width: 650px; margin-top: 16px; font-size: 17px; line-height: 1.65; }
 
-.home-proof { display: grid; grid-template-columns: repeat(3, 1fr); padding-block: 0 78px; }
-.home-proof p { display: flex; flex-direction: column; gap: 7px; margin: 0; padding: 18px 20px; border: 1px solid #e1e4e9; border-right: 0; }
+.home-proof { display: grid; grid-template-columns: repeat(3, 1fr); padding-bottom: 80px; }
+.home-proof p {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 17px 20px;
+  border: 1px solid #e1e4e9;
+  border-right: 0;
+}
 .home-proof p:last-child { border-right: 1px solid #e1e4e9; }
-.home-proof strong { color: #5e6675; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.home-proof strong { color: #5e6675; font-size: 12px; font-weight: 650; text-transform: uppercase; }
 .home-proof span { color: #111827; font: 600 13px/1.4 var(--vp-font-family-mono); }
 
-.home-demo { display: grid; grid-template-columns: .85fr 1.35fr; align-items: stretch; padding-bottom: 96px; }
-.home-demo-copy { padding: 52px 50px 52px 0; }
-.home-demo-copy > p:not(.section-kicker) { max-width: 510px; margin-top: 20px; font-size: 17px; line-height: 1.65; }
-.home-demo-actions { display: flex; flex-wrap: wrap; gap: 22px; margin-top: 28px; }
+.home-demo {
+  display: grid;
+  grid-template-columns: minmax(0, .9fr) minmax(0, 1.1fr);
+  gap: 64px;
+  align-items: center;
+  padding-bottom: 88px;
+}
+.home-demo-copy { max-width: 480px; }
+.home-demo-copy > p { margin-top: 18px; font-size: 17px; line-height: 1.65; }
+.home-demo-actions { display: flex; flex-wrap: wrap; gap: 22px; margin-top: 26px; }
 .home-text-link { color: #1e55e6 !important; font-weight: 650; text-decoration: none !important; }
 .home-text-link:hover { text-decoration: underline !important; text-underline-offset: 4px; }
-.terminal-stage { min-width: 0; background: #12171e; color: #e7ebf1; border: 1px solid #29323e; font: 12px/1.55 var(--vp-font-family-mono); }
+.terminal-stage {
+  min-width: 0;
+  overflow: hidden;
+  background: #12171e;
+  color: #e7ebf1;
+  border: 1px solid #29323e;
+  font: 12px/1.55 var(--vp-font-family-mono);
+}
 .terminal-head { display: flex; justify-content: space-between; padding: 13px 16px; color: #9da7b5; border-bottom: 1px solid #29323e; }
 .terminal-head span:last-child { color: #7dd89b; }
-.terminal-line { display: flex; gap: 14px; padding: 26px 22px; color: #f7f9fc; border-bottom: 1px solid #29323e; font-size: 13px; }
+.terminal-line { display: flex; gap: 14px; padding: 24px 22px; color: #f7f9fc; border-bottom: 1px solid #29323e; font-size: 13px; }
 .terminal-line .prompt { color: #79a0ff; }
-.terminal-event { display: grid; grid-template-columns: 42px 150px 1fr; gap: 10px; padding: 19px 22px; border-bottom: 1px solid #29323e; }
+.terminal-event { display: grid; grid-template-columns: 34px 138px minmax(0, 1fr); gap: 10px; padding: 18px 22px; border-bottom: 1px solid #29323e; }
 .terminal-event > span:first-child { color: #79a0ff; }
 .terminal-event strong { color: #e7ebf1; font-weight: 600; }
 .terminal-event > span:last-child { color: #9da7b5; }
-.terminal-receipt { display: grid; grid-template-columns: 70px 1fr auto; gap: 12px; align-items: center; padding: 19px 22px; background: #171d25; }
+.terminal-receipt { display: grid; grid-template-columns: 64px minmax(0, 1fr) auto; gap: 12px; align-items: center; padding: 18px 22px; background: #171d25; }
 .terminal-receipt > span { color: #9da7b5; }
 .terminal-receipt code { min-width: 0; overflow: hidden; color: #e7ebf1; text-overflow: ellipsis; white-space: nowrap; }
 .terminal-receipt b { color: #7dd89b; font-weight: 650; }
 
-.download-section { padding-block: 96px !important; border-block: 1px solid #e1e4e9; }
-.download-grid { display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 42px; border: 1px solid #c8cdd6; }
-.download-option { display: flex; flex-direction: column; gap: 5px; min-height: 158px; padding: 24px; color: #111827 !important; border-right: 1px solid #c8cdd6; text-decoration: none !important; transition: background-color 150ms ease, color 150ms ease; }
+.download-section { padding-block: 78px !important; border-block: 1px solid #e1e4e9; }
+.download-grid { display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 36px; border: 1px solid #c8cdd6; }
+.download-option {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-height: 148px;
+  padding: 22px;
+  color: #111827 !important;
+  border-right: 1px solid #c8cdd6;
+  text-decoration: none !important;
+  transition: background-color 150ms ease, color 150ms ease;
+}
 .download-option:last-child { border-right: 0; }
 .download-option:hover { background: #1e55e6; color: #fff !important; }
-.download-os { margin-bottom: auto; color: #5e6675; font: 700 11px/1.4 var(--vp-font-family-mono); letter-spacing: .1em; text-transform: uppercase; }
+.download-os { margin-bottom: auto; color: #5e6675; font: 700 11px/1.4 var(--vp-font-family-mono); text-transform: uppercase; }
 .download-option:hover .download-os, .download-option:hover small { color: #dce6ff; }
 .download-option strong { font-size: 20px; letter-spacing: -.02em; }
 .download-option small { color: #7a8392; font: 12px/1.4 var(--vp-font-family-mono); }
-.download-footnote { margin-top: 18px; font-size: 13px; }
+.download-footnote { margin-top: 16px; font-size: 13px; }
 
-.mcp-section { padding-block: 96px !important; }
-.mcp-layout { display: grid; grid-template-columns: 1.15fr 1fr; gap: 48px; align-items: center; margin-top: 46px; }
-.mcp-code { background: #12171e; color: #e7ebf1; border: 1px solid #29323e; }
+.mcp-section { padding-block: 82px !important; }
+.mcp-layout { display: grid; grid-template-columns: 1.08fr .92fr; gap: 56px; align-items: center; margin-top: 38px; }
+.mcp-code { overflow: hidden; background: #12171e; color: #e7ebf1; border: 1px solid #29323e; }
 .mcp-code-head { display: flex; justify-content: space-between; padding: 12px 16px; color: #9da7b5; border-bottom: 1px solid #29323e; font: 11px/1.4 var(--vp-font-family-mono); }
-.mcp-code pre { margin: 0; padding: 24px; overflow: auto; background: transparent; font-size: 13px; line-height: 1.7; }
+.mcp-code pre { margin: 0; padding: 22px; overflow: auto; background: transparent; font-size: 13px; line-height: 1.7; }
 .mcp-code code { color: #e7ebf1; }
 .mcp-steps { margin: 0 !important; padding: 0 !important; list-style: none; }
-.mcp-steps li { display: grid; grid-template-columns: 38px 1fr; gap: 16px; padding: 19px 0; border-bottom: 1px solid #e1e4e9; }
+.mcp-steps li { display: grid; grid-template-columns: 34px 1fr; gap: 14px; padding: 17px 0; border-bottom: 1px solid #e1e4e9; }
 .mcp-steps li:first-child { border-top: 1px solid #e1e4e9; }
 .mcp-steps li > span { color: #1e55e6; font: 700 12px/1.4 var(--vp-font-family-mono); }
 .mcp-steps strong { color: #111827; font-size: 15px; }
-.mcp-steps p { margin: 5px 0 0; line-height: 1.55; }
-.host-links { display: flex; flex-wrap: wrap; gap: 0; margin-top: 32px; border: 1px solid #e1e4e9; }
-.host-links a { flex: 1 1 150px; padding: 14px 18px; color: #111827; border-right: 1px solid #e1e4e9; text-align: center; text-decoration: none; }
+.mcp-steps p { margin: 4px 0 0; line-height: 1.55; }
+.host-links { display: grid; grid-template-columns: repeat(4, 1fr); margin-top: 28px; border: 1px solid #e1e4e9; }
+.host-links a { padding: 13px 16px; color: #111827; border-right: 1px solid #e1e4e9; text-align: center; text-decoration: none; }
 .host-links a:last-child { border-right: 0; }
 .host-links a:hover { color: #1e55e6; background: #f5f6f9; }
 
-.boundary-section { display: grid; grid-template-columns: 1fr 1fr; gap: 70px; max-width: none !important; padding: 92px max(24px, calc((100vw - 1104px) / 2)) !important; background: #12171e; color: #e7ebf1; }
-.boundary-section .section-kicker { color: #79a0ff !important; }
+.boundary-section {
+  display: grid;
+  grid-template-columns: minmax(0, .95fr) minmax(0, 1.05fr);
+  gap: 76px;
+  padding: 84px max(24px, calc((100vw - 1104px) / 2)) !important;
+  background: #12171e;
+  color: #e7ebf1;
+}
 .boundary-section h2 { color: #f7f9fc; }
-.boundary-copy p { margin: 0 0 18px; color: #b4bdc9 !important; font-size: 16px; line-height: 1.65; }
+.boundary-copy p { margin: 0 0 17px; color: #b4bdc9 !important; font-size: 16px; line-height: 1.65; }
 .boundary-copy code { color: #e7ebf1; background: #1b222c; }
 .boundary-copy .home-text-link { color: #79a0ff !important; }
 
-.faq-section { display: grid; grid-template-columns: .72fr 1.28fr; gap: 72px; padding-block: 96px !important; }
+.faq-section { display: grid; grid-template-columns: .72fr 1.28fr; gap: 72px; padding-block: 82px !important; }
 .faq-list { border-top: 1px solid #c8cdd6; }
 .faq-list details { border-bottom: 1px solid #c8cdd6; }
-.faq-list summary { padding: 20px 34px 20px 0; color: #111827; font-weight: 650; cursor: pointer; }
-.faq-list details p { margin: -4px 0 20px; max-width: 660px; line-height: 1.65; }
+.faq-list summary { padding: 19px 34px 19px 0; color: #111827; font-weight: 650; cursor: pointer; }
+.faq-list details p { max-width: 660px; margin: -3px 0 19px; line-height: 1.65; }
 
-.final-cta { max-width: none !important; padding: 94px max(24px, calc((100vw - 1104px) / 2)) 104px !important; background: #edf2ff; text-align: center; }
-.final-cta h2 { max-width: 760px; margin-inline: auto !important; }
-.final-cta a { display: inline-flex; gap: 16px; align-items: center; min-height: 48px; margin-top: 30px; padding: 0 20px; background: #1e55e6; color: #fff; border-radius: 4px; font-weight: 650; text-decoration: none; }
+.final-cta { padding: 80px max(24px, calc((100vw - 1104px) / 2)) 86px !important; background: #edf2ff; text-align: center; }
+.final-cta h2 { max-width: 720px; margin-inline: auto !important; }
+.final-cta a { display: inline-flex; gap: 16px; align-items: center; min-height: 48px; margin-top: 27px; padding: 0 20px; background: #1e55e6; color: #fff; border-radius: 4px; font-weight: 650; text-decoration: none; }
 .final-cta a:hover { background: #1647ca; }
 
-@media (max-width: 820px) {
-  .VPHero { padding-top: 60px !important; }
-  .home-proof { grid-template-columns: 1fr; }
-  .home-proof p, .home-proof p:last-child { border: 1px solid #e1e4e9; border-bottom: 0; }
-  .home-proof p:last-child { border-bottom: 1px solid #e1e4e9; }
-  .home-demo, .mcp-layout, .boundary-section, .faq-section { grid-template-columns: 1fr; gap: 36px; }
-  .home-demo-copy { padding: 0; }
-  .download-grid { grid-template-columns: 1fr; }
-  .download-option, .download-option:last-child { min-height: 132px; border-right: 0; border-bottom: 1px solid #c8cdd6; }
-  .download-option:last-child { border-bottom: 0; }
-  .boundary-section { padding-block: 72px !important; }
+@media (max-width: 960px) {
+  .VPHero { padding-top: 64px !important; }
+  .VPHero .image-container { width: 190px; height: 190px; }
+  .VPHero .image-src { width: 190px; height: 190px; }
+  .home-demo, .mcp-layout, .boundary-section, .faq-section { grid-template-columns: 1fr; gap: 34px; }
+  .home-demo-copy { max-width: 650px; }
+  .host-links { grid-template-columns: repeat(2, 1fr); }
+  .host-links a:nth-child(2) { border-right: 0; }
+  .host-links a:nth-child(-n+2) { border-bottom: 1px solid #e1e4e9; }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 700px) {
+  .VPHero { padding: 54px 18px 48px !important; }
+  .VPHero .image { display: none; }
   .VPHero .text { font-size: 42px; }
-  .VPHome .vp-doc > section { padding-inline: 18px; }
-  .terminal-event { grid-template-columns: 32px 1fr; }
+  .VPHome section:not(.boundary-section):not(.final-cta) { padding-inline: 18px; }
+  .home-proof { grid-template-columns: 1fr; padding-bottom: 62px; }
+  .home-proof p, .home-proof p:last-child { border: 1px solid #e1e4e9; border-bottom: 0; }
+  .home-proof p:last-child { border-bottom: 1px solid #e1e4e9; }
+  .home-demo { padding-bottom: 68px; }
+  .download-section, .mcp-section, .faq-section { padding-block: 66px !important; }
+  .download-grid { grid-template-columns: 1fr; }
+  .download-option, .download-option:last-child { min-height: 126px; border-right: 0; border-bottom: 1px solid #c8cdd6; }
+  .download-option:last-child { border-bottom: 0; }
+  .boundary-section, .final-cta { padding: 66px 18px !important; }
+}
+
+@media (max-width: 460px) {
+  .terminal-event { grid-template-columns: 28px 1fr; }
   .terminal-event > span:last-child { grid-column: 2; }
   .terminal-receipt { grid-template-columns: 1fr auto; }
   .terminal-receipt code { grid-column: 1 / -1; grid-row: 2; }
-  .boundary-section, .final-cta { padding-inline: 18px !important; }
+  .host-links { grid-template-columns: 1fr; }
+  .host-links a { border-right: 0; border-bottom: 1px solid #e1e4e9; }
+  .host-links a:last-child { border-bottom: 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,15 @@
 ---
 layout: home
-title: Rookhold Sandbox
+title: Rookhold
 titleTemplate: Controlled code execution for AI agents
 description: Download the Rookhold CLI and connect Claude Code, OpenCode, Hermes, or another MCP host to a controlled execution service.
 
 hero:
-  name: Rookhold
   text: Run agent code behind a boundary you control.
   tagline: One downloadable CLI connects your app or agent to short Python, Node, and Bash jobs with hard limits, bounded live output, and a verifiable receipt.
+  image:
+    src: /rook.svg
+    alt: Rookhold black-square emblem
   actions:
     - theme: brand
       text: Download the CLI
@@ -15,14 +17,6 @@ hero:
     - theme: alt
       text: Connect an MCP host
       link: /use/mcp
-
-features:
-  - title: One consumer file
-    details: Download rookhold-cli for Windows, macOS, or Linux. No Python, Node, Rust, or source checkout is required.
-  - title: CLI and MCP together
-    details: Use the terminal directly, or launch the same file with mcp-server from Claude Code, OpenCode, Hermes, and other MCP hosts.
-  - title: Evidence after every run
-    details: Limits, output hashes, runtime facts, isolation, completion state, and the event-chain head stay with the result.
 ---
 
 <section class="home-proof" aria-label="Release facts">
@@ -33,8 +27,7 @@ features:
 
 <section class="home-demo" aria-labelledby="demo-heading">
   <div class="home-demo-copy">
-    <p class="section-kicker">ONE FILE · TWO INTERFACES</p>
-    <h2 id="demo-heading">Use it yourself. Or give it to your agent.</h2>
+    <h2 id="demo-heading">One file for you and your agent.</h2>
     <p>The normal command opens Rookhold's operator CLI. The <code>mcp-server</code> argument turns that same executable into a concurrent stdio MCP server with four narrow execution tools.</p>
     <div class="home-demo-actions">
       <a class="home-text-link" href="./use/cli">Open the CLI guide <span aria-hidden="true">→</span></a>
@@ -52,9 +45,8 @@ features:
 
 <section id="download" class="download-section" aria-labelledby="download-heading">
   <div class="section-heading">
-    <p class="section-kicker">DOWNLOAD v0.7.1</p>
-    <h2 id="download-heading">Pick your operating system.</h2>
-    <p>Each link is a single standalone CLI file from the immutable GitHub release. Keep it at a stable path; agent hosts launch the same file with <code>mcp-server</code>.</p>
+    <h2 id="download-heading">Download Rookhold v0.7.1.</h2>
+    <p>Each link is one standalone CLI file from the immutable GitHub release. Keep it at a stable path; agent hosts launch the same file with <code>mcp-server</code>.</p>
   </div>
   <div class="download-grid">
     <a class="download-option" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe">
@@ -72,7 +64,6 @@ features:
 
 <section class="mcp-section" aria-labelledby="mcp-heading">
   <div class="section-heading">
-    <p class="section-kicker">AGENT INTEGRATION</p>
     <h2 id="mcp-heading">Connect any local MCP host.</h2>
     <p>Rookhold keeps the endpoint, credential, allowed languages, and minimum isolation outside the model's tool arguments.</p>
   </div>
@@ -104,7 +95,6 @@ features:
 
 <section class="boundary-section" aria-labelledby="boundary-heading">
   <div>
-    <p class="section-kicker">THE SECURITY BOUNDARY</p>
     <h2 id="boundary-heading">The website is hosted. The executor is yours.</h2>
   </div>
   <div class="boundary-copy">
@@ -115,7 +105,7 @@ features:
 </section>
 
 <section class="faq-section" aria-labelledby="faq-heading">
-  <div class="section-heading"><p class="section-kicker">BEFORE YOU START</p><h2 id="faq-heading">The short answers.</h2></div>
+  <div class="section-heading"><h2 id="faq-heading">The short answers.</h2></div>
   <div class="faq-list">
     <details><summary>Does the CLI include the sandbox service?</summary><p>The full release archive includes the service and verifier. The one-file CLI is the consumer interface and connects to a separately operated Rookhold endpoint.</p></details>
     <details><summary>Does MCP replace Claude Code or OpenCode?</summary><p>No. Your existing host owns the conversation and model. Rookhold adds four execution tools with policy and evidence.</p></details>
@@ -125,7 +115,6 @@ features:
 </section>
 
 <section class="final-cta" aria-label="Download Rookhold">
-  <p class="section-kicker">SHORT JOBS · HARD LIMITS · RECEIPTS</p>
   <h2>Give your agent a controlled place to run code.</h2>
   <a href="#download">Download Rookhold v0.7.1 <span aria-hidden="true">↓</span></a>
 </section>

--- a/docs/public/rook.svg
+++ b/docs/public/rook.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Rookhold"><path fill="#1e55e6" d="M7 3h4v5h3V3h4v5h3V3h4v9l-3 3v10h3v4H7v-4h3V15l-3-3V3Zm7 12v10h4V15h-4Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Rookhold">
+  <rect width="64" height="64" fill="#101318"/>
+  <path fill="#fff" d="M15 14h8v8h6v-8h6v8h6v-8h8v18l-6 6v12h7v6H14v-6h7V38l-6-6V14Zm8 14h18v-8h-2v6h-4v-6h-6v6h-4v-6h-2v8Zm6 10v12h6V38h-6Z"/>
+</svg>


### PR DESCRIPTION
## Contribution tier

Tier C — public production-site identity and responsive layout change.

## Declared scope

Replace the blue rook mark with a black-square SVG website identity and correct the messy desktop homepage composition without changing product claims, download targets, MCP behavior, or documentation information architecture.

## Root invariant

The page must preserve Rookhold's truthful separation between the hosted documentation, immutable GitHub release downloads, local unisolated development, and the self-hosted Linux gVisor execution boundary.

## Reproduction and RED evidence

RED: at 1440px the custom homepage sections rendered at the full 1425px page width because `.VPHome .vp-doc > section` never matched the generated VitePress DOM. The copy and terminal touched opposite viewport edges, the hero left an unused right column, and a redundant feature-card row competed with the release-fact strip.

## Changes

- replace the blue rook-only SVG with a crisp white rook inside a black square
- use the SVG as navbar identity, favicon, and balanced desktop hero visual
- remove the redundant feature cards, decorative eyebrow labels, and appearance-toggle clutter
- simplify navigation labels and restyle local search to the chalk surface
- target the actual generated homepage sections and align them to one 1152px desktop grid
- tighten section spacing and reduce total page height while retaining the full-width security and final-action surfaces
- preserve responsive single-column behavior and existing product copy

## Adversarial coverage

- [x] 1440x900 desktop: all ordinary sections measure 1152px and share the same left/right edge
- [x] 1440x900 desktop: no horizontal overflow, no feature-card duplication, and no console warnings/errors
- [x] 390x844 mobile: no horizontal overflow, mobile navigation is present, and download/host grids collapse to one column
- [x] Vercel-root and GitHub Pages subpath builds both pass
- [x] built output contains the SVG asset and favicon link

## Validation

- Head: 51b97c2447f64b9ddd646809d4560788c784e042
- Checks: Impeccable layout detector; whitespace check; release-surface contract; Vercel-root VitePress build; GitHub Pages subpath VitePress build; built SVG/favicon assertions; desktop and mobile browser measurements and screenshots.

## Non-goals and remaining work

No server, CLI, MCP, SDK, execution provider, release artifact, dashboard workflow, or security policy behavior changes. The execution service remains self-hosted.

## Safety and compatibility

The SVG is dependency-free and served from the existing VitePress public directory. Both deployment bases remain supported. Download and integration URLs are unchanged, reduced-motion behavior remains intact, focus treatment is explicit, and mobile DOM order matches the desktop reading order.

## Completion state

- Implementation: complete
- Validation: complete
- Review: complete; CI and Vercel review are green
- Integration: complete; merged as 5bc1d27 and the main Vercel deployment is Ready

