### PR TITLE
docs: simplify download choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ runs the MCP server for Claude Code, OpenCode, and other agent CLIs.
 
 | Your computer | Single-file CLI |
 |---|---|
-| Windows | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe) |
-| Mac | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin) |
-| Linux | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu) |
+| Windows, 64-bit | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe) |
+| Mac with Apple silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin) |
+| Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu) |
 
 Run it normally for the interactive CLI. Register the same path plus the
 `mcp-server` argument in an MCP host. On macOS or Linux, mark the download
@@ -128,9 +128,9 @@ Choose the complete app bundle for your computer:
 
 | Your computer | Download the complete app bundle |
 |---|---|
-| Windows | [Download the Windows app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-pc-windows-msvc.zip) |
-| Mac | [Download the Mac app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-aarch64-apple-darwin.tar.gz) |
-| Linux | [Download the Linux app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-unknown-linux-musl.tar.gz) |
+| Windows, 64-bit | [Download the Windows app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-pc-windows-msvc.zip) |
+| Mac with Apple silicon | [Download the Mac app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-aarch64-apple-darwin.tar.gz) |
+| Linux x86_64 | [Download the Linux app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-unknown-linux-musl.tar.gz) |
 
 Extract the archive. It contains the Rookhold service, `rookhold-cli`,
 `rookhold-mcp`, verification tools, and the copy-ready agent configurations.

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ runs the MCP server for Claude Code, OpenCode, and other agent CLIs.
 
 | Your computer | Single-file CLI |
 |---|---|
-| Windows, 64-bit | [`rookhold-cli-x86_64-pc-windows-msvc.exe`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe) |
-| Mac with Apple silicon | [`rookhold-cli-aarch64-apple-darwin`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin) |
-| Linux x86_64 | [`rookhold-cli-x86_64-unknown-linux-gnu`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu) |
+| Windows | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe) |
+| Mac | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin) |
+| Linux | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu) |
 
 Run it normally for the interactive CLI. Register the same path plus the
 `mcp-server` argument in an MCP host. On macOS or Linux, mark the download
@@ -124,14 +124,13 @@ source checkout.
 
 ### 1. Download the app
 
-Open the current [v0.7.1 release](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1),
-then choose the archive for your computer:
+Choose the complete app bundle for your computer:
 
 | Your computer | Download the complete app bundle |
 |---|---|
-| Windows, 64-bit | [`rookhold-x86_64-pc-windows-msvc.zip`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-pc-windows-msvc.zip) |
-| Mac with Apple silicon | [`rookhold-aarch64-apple-darwin.tar.gz`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-aarch64-apple-darwin.tar.gz) |
-| Linux x86_64 | [`rookhold-x86_64-unknown-linux-musl.tar.gz`](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-unknown-linux-musl.tar.gz) |
+| Windows | [Download the Windows app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-pc-windows-msvc.zip) |
+| Mac | [Download the Mac app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-aarch64-apple-darwin.tar.gz) |
+| Linux | [Download the Linux app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-unknown-linux-musl.tar.gz) |
 
 Extract the archive. It contains the Rookhold service, `rookhold-cli`,
 `rookhold-mcp`, verification tools, and the copy-ready agent configurations.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -34,7 +34,7 @@ export default defineConfig({
       { text: "MCP", link: "/use/mcp" },
       { text: "Security", link: "/security-boundary" },
       { text: "Deploy", link: "/deployment" },
-      { text: "Download v0.7.1", link: "https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1" },
+      { text: "Download", link: "/#download" },
     ],
     sidebar: {
       "/getting-started/": [

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -142,6 +142,7 @@ body { background: #fdfeff; }
 .download-option:last-child { border-right: 0; }
 .download-option:hover { background: #1e55e6; color: #fff !important; }
 .download-option strong { font-size: 18px; letter-spacing: -.02em; }
+.download-compatibility { max-width: 720px; margin-top: 14px; font-size: 13px; line-height: 1.55; }
 
 .mcp-section { padding-block: 82px !important; }
 .mcp-layout { display: grid; grid-template-columns: 1.08fr .92fr; gap: 56px; align-items: center; margin-top: 38px; }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -127,13 +127,13 @@ body { background: #fdfeff; }
 .terminal-receipt b { color: #7dd89b; font-weight: 650; }
 
 .download-section { padding-block: 78px !important; border-block: 1px solid #e1e4e9; }
-.download-grid { display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 36px; border: 1px solid #c8cdd6; }
+.download-grid { display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 32px; border: 1px solid #c8cdd6; }
 .download-option {
   display: flex;
-  flex-direction: column;
-  gap: 5px;
-  min-height: 148px;
-  padding: 22px;
+  align-items: center;
+  justify-content: center;
+  min-height: 88px;
+  padding: 20px;
   color: #111827 !important;
   border-right: 1px solid #c8cdd6;
   text-decoration: none !important;
@@ -141,11 +141,7 @@ body { background: #fdfeff; }
 }
 .download-option:last-child { border-right: 0; }
 .download-option:hover { background: #1e55e6; color: #fff !important; }
-.download-os { margin-bottom: auto; color: #5e6675; font: 700 11px/1.4 var(--vp-font-family-mono); text-transform: uppercase; }
-.download-option:hover .download-os, .download-option:hover small { color: #dce6ff; }
-.download-option strong { font-size: 20px; letter-spacing: -.02em; }
-.download-option small { color: #7a8392; font: 12px/1.4 var(--vp-font-family-mono); }
-.download-footnote { margin-top: 16px; font-size: 13px; }
+.download-option strong { font-size: 18px; letter-spacing: -.02em; }
 
 .mcp-section { padding-block: 82px !important; }
 .mcp-layout { display: grid; grid-template-columns: 1.08fr .92fr; gap: 56px; align-items: center; margin-top: 38px; }
@@ -210,7 +206,7 @@ body { background: #fdfeff; }
   .home-demo { padding-bottom: 68px; }
   .download-section, .mcp-section, .faq-section { padding-block: 66px !important; }
   .download-grid { grid-template-columns: 1fr; }
-  .download-option, .download-option:last-child { min-height: 126px; border-right: 0; border-bottom: 1px solid #c8cdd6; }
+  .download-option, .download-option:last-child { min-height: 72px; border-right: 0; border-bottom: 1px solid #c8cdd6; }
   .download-option:last-child { border-bottom: 0; }
   .boundary-section, .final-cta { padding: 66px 18px !important; }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,19 +46,20 @@ hero:
 <section id="download" class="download-section" aria-labelledby="download-heading">
   <div class="section-heading">
     <h2 id="download-heading">Download Rookhold.</h2>
-    <p>Choose your computer. Each option is one ready-to-run CLI file.</p>
+    <p>Choose your computer. Each option is one self-contained CLI file.</p>
   </div>
   <div class="download-grid">
-    <a class="download-option" aria-label="Download Rookhold for Windows" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe">
+    <a class="download-option" aria-label="Download Rookhold for 64-bit Windows" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe">
       <strong>Windows</strong>
     </a>
-    <a class="download-option" aria-label="Download Rookhold for Mac" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin">
+    <a class="download-option" aria-label="Download Rookhold for Apple silicon Mac" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin">
       <strong>Mac</strong>
     </a>
-    <a class="download-option" aria-label="Download Rookhold for Linux" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu">
+    <a class="download-option" aria-label="Download Rookhold for 64-bit Intel or AMD Linux" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu">
       <strong>Linux</strong>
     </a>
   </div>
+  <p class="download-compatibility">Windows and Linux: 64-bit Intel or AMD. Mac: Apple silicon. Mac and Linux users run <code>chmod +x</code> once after downloading.</p>
 </section>
 
 <section class="mcp-section" aria-labelledby="mcp-heading">

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,21 +45,20 @@ hero:
 
 <section id="download" class="download-section" aria-labelledby="download-heading">
   <div class="section-heading">
-    <h2 id="download-heading">Download Rookhold v0.7.1.</h2>
-    <p>Each link is one standalone CLI file from the immutable GitHub release. Keep it at a stable path; agent hosts launch the same file with <code>mcp-server</code>.</p>
+    <h2 id="download-heading">Download Rookhold.</h2>
+    <p>Choose your computer. Each option is one ready-to-run CLI file.</p>
   </div>
   <div class="download-grid">
-    <a class="download-option" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe">
-      <span class="download-os">Windows</span><strong>Download .exe</strong><small>x86_64 · 9.1 MB</small>
+    <a class="download-option" aria-label="Download Rookhold for Windows" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe">
+      <strong>Windows</strong>
     </a>
-    <a class="download-option" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin">
-      <span class="download-os">macOS</span><strong>Download binary</strong><small>Apple Silicon · 8.2 MB</small>
+    <a class="download-option" aria-label="Download Rookhold for Mac" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin">
+      <strong>Mac</strong>
     </a>
-    <a class="download-option" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu">
-      <span class="download-os">Linux</span><strong>Download binary</strong><small>x86_64 GNU · 21.0 MB</small>
+    <a class="download-option" aria-label="Download Rookhold for Linux" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu">
+      <strong>Linux</strong>
     </a>
   </div>
-  <p class="download-footnote">Need the server, verifier, SDKs, checksums, or another platform? <a href="https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1">View every release asset</a>.</p>
 </section>
 
 <section class="mcp-section" aria-labelledby="mcp-heading">


### PR DESCRIPTION
## Contribution tier

Tier B — consumer-facing documentation and download-label refinement.

## Declared scope

Reduce the beginner download path to three plain operating-system choices and stop routing normal users to GitHub's mixed release-asset inventory.

## Changes

- label the website choices only as Windows, Mac, and Linux
- remove filenames, formats, architectures, sizes, version noise, and the advanced release-assets link from the homepage download area
- make the navbar Download action jump directly to the three choices
- replace raw CLI and app-bundle filenames in README tables with plain-language download labels
- retain the exact existing immutable release URLs behind every choice
- update the GitHub repository website field to https://rookhold.vercel.app/

## Validation

- Head: 227d7bd12628fa82ad71e6d2a97d96e47e3f976c
- Checks: Impeccable layout detector; whitespace check; release-surface contract; Vercel-root VitePress build; GitHub Pages subpath build; built-home assertion for exactly three options labeled Windows, Mac, and Linux; assertion that the advanced release-assets link is absent from the homepage.

## Safety and compatibility

Only labels and navigation changed. Release artifacts, hashes, URLs, CLI behavior, MCP behavior, SDK packages, server bundles, checksums, SBOM, and provenance remain available and unchanged. Accessibility names identify each download destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified platform labels across CLI and complete app bundle download tables.
  - Updated the documentation site’s Download navigation to open the in-page download section.
  - Added concise platform-specific download cards with accessible labels and direct release links.
  - Simplified download instructions and removed outdated release-related wording.

- **Style**
  - Refined download cards with a more compact, centered layout.
  - Improved spacing and sizing for desktop and mobile displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



Integration: complete; merged as cbbf363 and production is Ready.
