### PR TITLE
release: make v0.8.0 the complete public developer path

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -69,8 +69,8 @@ jobs:
         run: |
           suffix=
           if [ "$RUNNER_OS" = Windows ]; then suffix=.exe; fi
-          "target/debug/rookhold${suffix}" run python 'print(6 * 7)' --json | \
-            python -c 'import json, sys; value=json.load(sys.stdin); assert value["result"]["stdout"] == "42" and value["result"]["status"] == "succeeded"'
+          "target/debug/rookhold${suffix}" run python 'print(6 * 7)' --json > local-demo.json
+          python scripts/verify-local-demo.py local-demo.json
 
   examples-and-mcp:
     name: recipes and MCP configuration

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,8 +23,10 @@ permissions:
 
 jobs:
   publish-pypi:
+    name: publish immutable Python package
     if: inputs.registry == 'pypi' || inputs.registry == 'both'
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     environment:
       name: release
     permissions:
@@ -84,8 +86,10 @@ jobs:
           --registry pypi --version "$RELEASE_VERSION" --dist package-dist
 
   publish-npm:
+    name: publish immutable TypeScript package
     if: inputs.registry == 'npm' || inputs.registry == 'both'
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     environment:
       name: release
     permissions:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -44,13 +44,13 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
           test "$(gh release view "v${RELEASE_VERSION}" --json isDraft --jq .isDraft)" = false
-          mkdir package-dist
+          mkdir downloads package-dist
           gh release download "v${RELEASE_VERSION}" \
             --pattern "rookhold-${RELEASE_VERSION}-py3-none-any.whl" \
             --pattern "rookhold-${RELEASE_VERSION}.tar.gz" \
             --pattern SHA256SUMS \
-            --dir package-dist
-          cd package-dist
+            --dir downloads
+          cd downloads
           for asset in "rookhold-${RELEASE_VERSION}-py3-none-any.whl" "rookhold-${RELEASE_VERSION}.tar.gz"; do
             digest="$(awk -v file="$asset" '$2 == file { print $1 }' SHA256SUMS)"
             test "${#digest}" -eq 64
@@ -60,6 +60,7 @@ jobs:
               --source-ref "refs/tags/v${RELEASE_VERSION}" \
               --predicate-type https://slsa.dev/provenance/v1 \
               --deny-self-hosted-runners
+            cp "$asset" ../package-dist/
           done
       - name: Check for an exact existing PyPI release
         id: registry-state

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,145 @@
+name: publish deferred SDK packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      registry:
+        description: Package registry to publish
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - pypi
+          - npm
+      version:
+        description: Existing immutable GitHub release version
+        required: true
+        default: 0.8.0
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-pypi:
+    if: inputs.registry == 'pypi' || inputs.registry == 'both'
+    runs-on: ubuntu-24.04
+    environment:
+      name: release
+    permissions:
+      contents: read # download and verify immutable release assets
+      id-token: write # exchange GitHub OIDC for a short-lived PyPI credential
+    steps:
+      - name: Check out publisher verification code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Download exact Python release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          test "$(gh release view "v${RELEASE_VERSION}" --json isDraft --jq .isDraft)" = false
+          mkdir package-dist
+          gh release download "v${RELEASE_VERSION}" \
+            --pattern "rookhold-${RELEASE_VERSION}-py3-none-any.whl" \
+            --pattern "rookhold-${RELEASE_VERSION}.tar.gz" \
+            --pattern SHA256SUMS \
+            --dir package-dist
+          cd package-dist
+          for asset in "rookhold-${RELEASE_VERSION}-py3-none-any.whl" "rookhold-${RELEASE_VERSION}.tar.gz"; do
+            digest="$(awk -v file="$asset" '$2 == file { print $1 }' SHA256SUMS)"
+            test "${#digest}" -eq 64
+            printf '%s  %s\n' "$digest" "$asset" | sha256sum --check --strict -
+            gh attestation verify "$asset" --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml" \
+              --source-ref "refs/tags/v${RELEASE_VERSION}" \
+              --predicate-type https://slsa.dev/provenance/v1 \
+              --deny-self-hosted-runners
+          done
+      - name: Check for an exact existing PyPI release
+        id: registry-state
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: >-
+          echo "state=$(python3 scripts/reconcile-registries.py status
+          --registry pypi --version "$RELEASE_VERSION" --dist package-dist)"
+          >> "$GITHUB_OUTPUT"
+      - name: Publish exact files with PyPI trusted publishing
+        if: steps.registry-state.outputs.state == 'missing'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: package-dist
+          attestations: true
+      - name: Reconcile published PyPI bytes
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: >-
+          python3 scripts/reconcile-registries.py verify
+          --registry pypi --version "$RELEASE_VERSION" --dist package-dist
+
+  publish-npm:
+    if: inputs.registry == 'npm' || inputs.registry == 'both'
+    runs-on: ubuntu-24.04
+    environment:
+      name: release
+    permissions:
+      contents: read # download and verify the immutable release tarball
+      id-token: write # exchange GitHub OIDC for a short-lived npm credential
+    steps:
+      - name: Check out publisher verification code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Download exact TypeScript release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          test "$(gh release view "v${RELEASE_VERSION}" --json isDraft --jq .isDraft)" = false
+          mkdir package-dist
+          gh release download "v${RELEASE_VERSION}" \
+            --pattern "rookhold-${RELEASE_VERSION}.tgz" \
+            --pattern SHA256SUMS \
+            --dir package-dist
+          cd package-dist
+          asset="rookhold-${RELEASE_VERSION}.tgz"
+          digest="$(awk -v file="$asset" '$2 == file { print $1 }' SHA256SUMS)"
+          test "${#digest}" -eq 64
+          printf '%s  %s\n' "$digest" "$asset" | sha256sum --check --strict -
+          gh attestation verify "$asset" --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml" \
+            --source-ref "refs/tags/v${RELEASE_VERSION}" \
+            --predicate-type https://slsa.dev/provenance/v1 \
+            --deny-self-hosted-runners
+      - name: Set up Node for npm trusted publishing
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+      - name: Check for an exact existing npm release
+        id: registry-state
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: >-
+          echo "state=$(python3 scripts/reconcile-registries.py status
+          --registry npm --version "$RELEASE_VERSION" --dist package-dist)"
+          >> "$GITHUB_OUTPUT"
+      - name: Publish exact tarball with npm trusted publishing
+        if: steps.registry-state.outputs.state == 'missing'
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: npm publish "package-dist/rookhold-${RELEASE_VERSION}.tgz" --access public --provenance
+      - name: Reconcile published npm bytes
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: >-
+          python3 scripts/reconcile-registries.py verify
+          --registry npm --version "$RELEASE_VERSION" --dist package-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             echo "CHANGELOG.md still marks ${version} as unreleased" >&2
             exit 1
           fi
-          grep -Fq "[v${version}](https://github.com/sambai-dev/rookhold/releases/tag/v${version})" README.md
+          python3 -c 'import json,sys; data=json.load(open("release.json", encoding="utf-8")); sys.exit(data.get("current_version") != sys.argv[1])' "$version"
           series="${version%.*}.x"
           grep -Fq "| tagged \`${series}\` releases | Supported |" SECURITY.md
           echo "version=${version}" >> "$GITHUB_OUTPUT"
@@ -655,9 +655,13 @@ jobs:
     environment:
       name: release
     permissions:
-      contents: read
-      id-token: write
+      contents: read # checkout the reviewed release helper
+      id-token: write # exchange GitHub OIDC for short-lived registry credentials
     steps:
+      - name: Check out source without persisting credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Download the exact gated SDK packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -670,7 +674,20 @@ jobs:
           mkdir pypi-dist
           cp "sdk-dist/rookhold-${{ needs.preflight.outputs.version }}-py3-none-any.whl" pypi-dist/
           cp "sdk-dist/rookhold-${{ needs.preflight.outputs.version }}.tar.gz" pypi-dist/
+      - name: Reconcile any prior partial registry publication by digest
+        id: registry-state
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pypi_state="$(python3 scripts/reconcile-registries.py status \
+            --registry pypi --version "$RELEASE_VERSION" --dist pypi-dist)"
+          npm_state="$(python3 scripts/reconcile-registries.py status \
+            --registry npm --version "$RELEASE_VERSION" --dist sdk-dist)"
+          printf 'pypi=%s\nnpm=%s\n' "$pypi_state" "$npm_state" >> "$GITHUB_OUTPUT"
       - name: Publish to PyPI with GitHub trusted publishing
+        if: steps.registry-state.outputs.pypi == 'missing'
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: pypi-dist
@@ -681,10 +698,23 @@ jobs:
           node-version: "24"
           registry-url: https://registry.npmjs.org
       - name: Publish to npm with provenance
+        if: steps.registry-state.outputs.npm == 'missing'
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
         run: >-
           npm publish
-          "sdk-dist/rookhold-${{ needs.preflight.outputs.version }}.tgz"
+          "sdk-dist/rookhold-${RELEASE_VERSION}.tgz"
           --access public --provenance
+      - name: Verify both public registries match the gated package bytes
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/reconcile-registries.py verify \
+            --registry pypi --version "$RELEASE_VERSION" --dist pypi-dist
+          python3 scripts/reconcile-registries.py verify \
+            --registry npm --version "$RELEASE_VERSION" --dist sdk-dist
 
   registry-smoke:
     name: clean public-package install
@@ -723,10 +753,12 @@ jobs:
       name: release
       url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     permissions:
-      contents: write
+      contents: write # publish the already reconciled GitHub release draft
     steps:
-      - name: Check out source
+      - name: Check out source without persisting credentials
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Download the reconciled eleven-asset set
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -735,6 +767,7 @@ jobs:
       - name: Re-verify the remote draft immediately before publication
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -744,7 +777,7 @@ jobs:
           python3 scripts/release-artifacts.py verify-release \
             --dist dist \
             --metadata "$metadata" \
-            --version "${{ needs.preflight.outputs.version }}" \
+            --version "$RELEASE_VERSION" \
             --tag "$GITHUB_REF_NAME"
       - name: Publish only after public registry smoke succeeds
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,21 @@ jobs:
             echo "Configure the protected release environment/tag rules described in docs/releasing.md, then set ROOKHOLD_RELEASE_GOVERNANCE=enabled" >&2
             exit 1
           fi
+      - name: Require configured registry trusted publishers
+        env:
+          PYPI_TRUSTED_PUBLISHER: ${{ vars.ROOKHOLD_PYPI_TRUSTED_PUBLISHER }}
+          NPM_TRUSTED_PUBLISHER: ${{ vars.ROOKHOLD_NPM_TRUSTED_PUBLISHER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$PYPI_TRUSTED_PUBLISHER" != enabled ]; then
+            echo "Configure the pending PyPI publisher for release.yml and the release environment, then set ROOKHOLD_PYPI_TRUSTED_PUBLISHER=enabled" >&2
+            exit 1
+          fi
+          if [ "$NPM_TRUSTED_PUBLISHER" != enabled ]; then
+            echo "Bootstrap the npm package, configure its release.yml trusted publisher for the release environment, then set ROOKHOLD_NPM_TRUSTED_PUBLISHER=enabled" >&2
+            exit 1
+          fi
       - name: Require a concrete build revision
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,21 +37,6 @@ jobs:
             echo "Configure the protected release environment/tag rules described in docs/releasing.md, then set ROOKHOLD_RELEASE_GOVERNANCE=enabled" >&2
             exit 1
           fi
-      - name: Require configured registry trusted publishers
-        env:
-          PYPI_TRUSTED_PUBLISHER: ${{ vars.ROOKHOLD_PYPI_TRUSTED_PUBLISHER }}
-          NPM_TRUSTED_PUBLISHER: ${{ vars.ROOKHOLD_NPM_TRUSTED_PUBLISHER }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "$PYPI_TRUSTED_PUBLISHER" != enabled ]; then
-            echo "Configure the pending PyPI publisher for release.yml and the release environment, then set ROOKHOLD_PYPI_TRUSTED_PUBLISHER=enabled" >&2
-            exit 1
-          fi
-          if [ "$NPM_TRUSTED_PUBLISHER" != enabled ]; then
-            echo "Bootstrap the npm package, configure its release.yml trusted publisher for the release environment, then set ROOKHOLD_NPM_TRUSTED_PUBLISHER=enabled" >&2
-            exit 1
-          fi
       - name: Require a concrete build revision
         shell: bash
         run: |
@@ -614,6 +599,9 @@ jobs:
           overwrite_files: false
           generate_release_notes: true
           draft: true
+          body: |
+            Package registry publication is deferred while maintainer accounts are activated.
+            The exact Python wheel and TypeScript tarball are included in this release and can be installed directly.
       - name: Reconcile the remote draft before publication
         env:
           GH_TOKEN: ${{ github.token }}
@@ -647,108 +635,49 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  publish-registries:
-    name: publish public SDK packages
+  package-smoke:
+    name: clean release-package install
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [preflight, stage-release]
-    environment:
-      name: release
-    permissions:
-      contents: read # checkout the reviewed release helper
-      id-token: write # exchange GitHub OIDC for short-lived registry credentials
     steps:
-      - name: Check out source without persisting credentials
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
       - name: Download the exact gated SDK packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rookhold-sdks
           path: sdk-dist
-      - name: Select only Python distribution files
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir pypi-dist
-          cp "sdk-dist/rookhold-${{ needs.preflight.outputs.version }}-py3-none-any.whl" pypi-dist/
-          cp "sdk-dist/rookhold-${{ needs.preflight.outputs.version }}.tar.gz" pypi-dist/
-      - name: Reconcile any prior partial registry publication by digest
-        id: registry-state
-        env:
-          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          pypi_state="$(python3 scripts/reconcile-registries.py status \
-            --registry pypi --version "$RELEASE_VERSION" --dist pypi-dist)"
-          npm_state="$(python3 scripts/reconcile-registries.py status \
-            --registry npm --version "$RELEASE_VERSION" --dist sdk-dist)"
-          printf 'pypi=%s\nnpm=%s\n' "$pypi_state" "$npm_state" >> "$GITHUB_OUTPUT"
-      - name: Publish to PyPI with GitHub trusted publishing
-        if: steps.registry-state.outputs.pypi == 'missing'
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: pypi-dist
-          attestations: true
-      - name: Set up Node for npm trusted publishing
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
-          registry-url: https://registry.npmjs.org
-      - name: Publish to npm with provenance
-        if: steps.registry-state.outputs.npm == 'missing'
-        env:
-          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
-        run: >-
-          npm publish
-          "sdk-dist/rookhold-${RELEASE_VERSION}.tgz"
-          --access public --provenance
-      - name: Verify both public registries match the gated package bytes
-        env:
-          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 scripts/reconcile-registries.py verify \
-            --registry pypi --version "$RELEASE_VERSION" --dist pypi-dist
-          python3 scripts/reconcile-registries.py verify \
-            --registry npm --version "$RELEASE_VERSION" --dist sdk-dist
-
-  registry-smoke:
-    name: clean public-package install
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    needs: [preflight, publish-registries]
-    steps:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - name: Install and import the exact PyPI release in a clean environment
+      - name: Install and import the exact release wheel in a clean environment
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           python -m venv clean-python
-          clean-python/bin/python -m pip install "rookhold==${{ needs.preflight.outputs.version }}"
+          clean-python/bin/python -m pip install --no-deps "sdk-dist/rookhold-${RELEASE_VERSION}-py3-none-any.whl"
           clean-python/bin/python -c "from rookhold import Rookhold, RunResult; assert callable(Rookhold.from_env); assert RunResult.__name__ == 'RunResult'"
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
-      - name: Install and import the exact npm release in a clean project
+      - name: Install and import the exact release tarball in a clean project
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
         shell: bash
         run: |
+          set -euo pipefail
           mkdir clean-node
           cd clean-node
           npm init -y
-          npm install "rookhold@${{ needs.preflight.outputs.version }}"
+          npm install "../sdk-dist/rookhold-${RELEASE_VERSION}.tgz"
           node --input-type=module -e "import { Rookhold, RunResult } from 'rookhold'; if (typeof Rookhold.fromEnv !== 'function' || typeof RunResult !== 'function') process.exit(1)"
 
   publish-release:
     name: publish GitHub release
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    needs: [preflight, stage-release, registry-smoke]
+    needs: [preflight, stage-release, package-smoke]
     environment:
       name: release
       url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
@@ -779,7 +708,7 @@ jobs:
             --metadata "$metadata" \
             --version "$RELEASE_VERSION" \
             --tag "$GITHUB_REF_NAME"
-      - name: Publish only after public registry smoke succeeds
+      - name: Publish only after exact package smoke succeeds
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,8 +485,8 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  publish:
-    name: publish release atomically
+  stage-release:
+    name: stage and reconcile release draft
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [preflight, sdk-gate, container-gate, hostile, build]
@@ -628,17 +628,30 @@ jobs:
             --metadata "$metadata" \
             --version "${{ needs.preflight.outputs.version }}" \
             --tag "$GITHUB_REF_NAME"
-      - name: Publish the fully staged release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: gh release edit "$GITHUB_REF_NAME" --draft=false --latest --verify-tag
+      - name: Preserve the reconciled eleven-asset set
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rookhold-release-staged
+          path: |
+            dist/rookhold-x86_64-unknown-linux-musl.tar.gz
+            dist/rookhold-aarch64-apple-darwin.tar.gz
+            dist/rookhold-x86_64-pc-windows-msvc.zip
+            dist/rookhold-cli-x86_64-unknown-linux-gnu
+            dist/rookhold-cli-aarch64-apple-darwin
+            dist/rookhold-cli-x86_64-pc-windows-msvc.exe
+            dist/rookhold-${{ needs.preflight.outputs.version }}-py3-none-any.whl
+            dist/rookhold-${{ needs.preflight.outputs.version }}.tar.gz
+            dist/rookhold-${{ needs.preflight.outputs.version }}.tgz
+            dist/rookhold-${{ needs.preflight.outputs.version }}.spdx.json
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 7
 
   publish-registries:
     name: publish public SDK packages
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    needs: [preflight, publish]
+    needs: [preflight, stage-release]
     environment:
       name: release
     permissions:
@@ -700,3 +713,41 @@ jobs:
           npm init -y
           npm install "rookhold@${{ needs.preflight.outputs.version }}"
           node --input-type=module -e "import { Rookhold, RunResult } from 'rookhold'; if (typeof Rookhold.fromEnv !== 'function' || typeof RunResult !== 'function') process.exit(1)"
+
+  publish-release:
+    name: publish GitHub release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [preflight, stage-release, registry-smoke]
+    environment:
+      name: release
+      url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+    permissions:
+      contents: write
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download the reconciled eleven-asset set
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rookhold-release-staged
+          path: dist
+      - name: Re-verify the remote draft immediately before publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          metadata="${RUNNER_TEMP}/rookhold-final-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --json assets,isDraft,tagName > "$metadata"
+          python3 scripts/release-artifacts.py verify-release \
+            --dist dist \
+            --metadata "$metadata" \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --tag "$GITHUB_REF_NAME"
+      - name: Publish only after public registry smoke succeeds
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false --latest --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes are documented here. Rookhold follows semantic versioning wh
 
 ### Why this matters
 
-Rookhold now starts with the developer outcome: install one public package or
+Rookhold now starts with the developer outcome: install one release package or
 run one command, submit a bounded job in one method call, and keep a receipt.
 Short real jobs can also receive bounded input files and return explicitly
 named, hashed output artifacts without gaining a persistent workspace.
@@ -15,8 +15,8 @@ named, hashed output artifacts without gaining a persistent workspace.
 
 ```bash
 rookhold run python 'while True: pass' --wall-seconds 2
-pip install rookhold
-npm install rookhold
+pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl
+npm install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz
 ```
 
 Python and TypeScript now provide `from_env`/`fromEnv`, `run`, structured JSON
@@ -30,8 +30,10 @@ preview and back up MCP host configuration changes.
 - The REST additions are optional fields; existing submit, event, result, and
   cancellation methods remain.
 - Python remains supported on 3.9–3.14 and TypeScript on Node 18+.
-- The public package name is now `rookhold` on both PyPI and npm. The Python
-  import remains `rookhold`; TypeScript applications should replace
+- The intended public package name is `rookhold` on both PyPI and npm. Named
+  registry installs are deferred while maintainer accounts are activated; the
+  immutable v0.8.0 wheel and tarball install directly from the GitHub release.
+  The Python import remains `rookhold`; TypeScript applications should replace
   `rookhold-sdk` imports with `rookhold`.
 - Internal `coop-*` crate names and durable v1 evidence identities remain to
   avoid a risky format rename.
@@ -42,9 +44,10 @@ preview and back up MCP host configuration changes.
   executors with path, count, per-file, and total-byte bounds.
 - Added versioned Bookworm runtime-pack names and bound them to existing
   interpreter, rootfs, runtime, and OCI configuration digests in receipts.
-- Added public-package trusted publishing, clean registry smoke tests, weekly
-  compatibility checks, executable recipes, Next.js and FastAPI starters, a
-  VitePress documentation site, and GitHub Pages deployment.
+- Added clean release-package smoke tests and a protected deferred registry
+  publisher that reuses immutable GitHub release bytes, plus weekly compatibility
+  checks, executable recipes, Next.js and FastAPI starters, a VitePress
+  documentation site, and GitHub Pages deployment.
 - Tiered contribution checks so docs and recipes no longer inherit the full
   security-core evidence process.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ verifiable receipt of what happened.
 [![Release](https://img.shields.io/github/v/release/sambai-dev/rookhold)](https://github.com/sambai-dev/rookhold/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Release candidate:** [v0.8.0](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0).
+**Release candidate:** v0.8.0. See [all releases](https://github.com/sambai-dev/rookhold/releases).
 The download and registry links below become available when the release
 workflow publishes. Until then, use the [source build](#build-from-source).
 
@@ -65,6 +65,9 @@ network      disabled
 isolation    gvisor-application-kernel
 receipt      saved to .rookhold/runs/019…/receipt.json
 ```
+
+The CLI explicitly requests `allow_network: false`; the guarded service must
+also report disabled networking and the required isolation class.
 
 [Read the quickstart](https://rookhold.vercel.app/getting-started/quickstart) ·
 [Deploy the secure boundary](https://rookhold.vercel.app/getting-started/first-secure-deployment)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ verifiable receipt of what happened.
 [![Release](https://img.shields.io/github/v/release/sambai-dev/rookhold)](https://github.com/sambai-dev/rookhold/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Current release:** [v0.8.0](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0)
+**Release candidate:** [v0.8.0](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0).
+The download and registry links below become available when the release
+workflow publishes. Until then, use the [source build](#build-from-source).
 
 Rookhold is for applications, agents, evaluators, graders, and automations that
 receive a short piece of code but should not hand it the host machine. It is a
@@ -16,13 +18,14 @@ or general-purpose cloud sandbox.
 
 ## Try Rookhold locally
 
-Choose the complete **Rookhold app** bundle. It contains the unified `rookhold`
-command, the remote client, MCP adapter, offline verifier, and setup templates.
+After v0.8.0 publishes, choose the complete **Rookhold app** bundle. It contains
+the unified `rookhold` command, remote client, MCP adapter, offline verifier,
+and setup templates.
 
 | Your computer | App bundle |
 |---|---|
 | Windows, 64-bit | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip) |
-| Mac with Apple silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
+| Mac with Apple Silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
 | Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz) |
 
 Extract the archive, then run one trusted local job:
@@ -74,6 +77,8 @@ untrusted workloads.
 
 ### Python
 
+After v0.8.0 publishes:
+
 ```bash
 pip install rookhold
 ```
@@ -86,6 +91,8 @@ print(result.stdout)
 ```
 
 ### TypeScript
+
+After v0.8.0 publishes:
 
 ```bash
 npm install rookhold
@@ -107,13 +114,14 @@ console.log(result.stdout);
 
 ## Connect to an existing Rookhold server
 
-The **Rookhold client** is the smallest download for a person or MCP host that
-already has a Rookhold endpoint. It does not include the local service.
+After v0.8.0 publishes, the **Rookhold client** is the smallest download for a
+person or MCP host that already has a Rookhold endpoint. It does not include
+the local service.
 
 | Your computer | Standalone client |
 |---|---|
 | Windows, 64-bit | [Download the Windows client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-pc-windows-msvc.exe) |
-| Mac with Apple silicon | [Download the Mac client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin) |
+| Mac with Apple Silicon | [Download the Mac client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin) |
 | Linux x86_64 | [Download the Linux client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu) |
 
 Run it normally for the operator terminal, or register the same file with the

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ untrusted workloads.
 After v0.8.0 publishes:
 
 ```bash
-pip install rookhold
+pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl
 ```
 
 ```python
@@ -98,8 +98,11 @@ print(result.stdout)
 After v0.8.0 publishes:
 
 ```bash
-npm install rookhold
+npm install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz
 ```
+
+Named PyPI and npm installs are temporarily deferred while maintainer registry
+accounts are activated. The release-hosted packages above contain the same SDKs.
 
 ```typescript
 import { Rookhold } from "rookhold";

--- a/README.md
+++ b/README.md
@@ -1,20 +1,60 @@
 # Rookhold
 
-Run short Python, Node, and Bash jobs with hard limits, live output, and a
-verifiable execution receipt.
+Run short-lived Python, Node, and Bash code with hard limits—and keep a
+verifiable receipt of what happened.
 
 [![CI](https://github.com/sambai-dev/rookhold/actions/workflows/ci.yml/badge.svg)](https://github.com/sambai-dev/rookhold/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/sambai-dev/rookhold)](https://github.com/sambai-dev/rookhold/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-> [!NOTE]
-> `rookhold run` and the `rookhold` registry packages are part of the upcoming
-> [v0.8.0](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0) release
-> and are available from `main` today. The current published release is
-> [v0.7.1](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1).
+**Current release:** [v0.8.0](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0)
+
+Rookhold is for applications, agents, evaluators, graders, and automations that
+receive a short piece of code but should not hand it the host machine. It is a
+bounded job runner—not a persistent workspace, browser environment, remote IDE,
+or general-purpose cloud sandbox.
+
+## Try Rookhold locally
+
+Choose the complete **Rookhold app** bundle. It contains the unified `rookhold`
+command, the remote client, MCP adapter, offline verifier, and setup templates.
+
+| Your computer | App bundle |
+|---|---|
+| Windows, 64-bit | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip) |
+| Mac with Apple silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
+| Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz) |
+
+Extract the archive, then run one trusted local job:
 
 ```console
 $ rookhold run python 'print(6 * 7)'
+42
+
+status       succeeded
+network      host
+isolation    none
+receipt      saved to .rookhold/runs/019…/receipt.json
+
+WARNING: isolation is none; this run did not contain untrusted code.
+```
+
+On macOS or Linux, run `chmod +x rookhold rookhold-cli rookhold-mcp
+rookhold-verify` once after extracting. On Windows, use `rookhold.exe`.
+
+> [!WARNING]
+> With no configured endpoint, `rookhold run` starts a temporary loopback-only
+> service for code you trust. It has host networking and no sandbox boundary.
+> Do not use this mode for hostile or mutually untrusted code.
+
+Connected to a guarded Linux service, the same command can require and report
+the gVisor boundary:
+
+```console
+$ ROOKHOLD_BASE_URL=https://executor.example \
+  ROOKHOLD_API_KEY=replace-with-a-scoped-key \
+  rookhold run python 'print(6 * 7)' \
+    --minimum-isolation gvisor-application-kernel
 42
 
 status       succeeded
@@ -23,17 +63,20 @@ isolation    gvisor-application-kernel
 receipt      saved to .rookhold/runs/019…/receipt.json
 ```
 
-Build the v0.8 SDKs from the current checkout:
+[Read the quickstart](https://rookhold.vercel.app/getting-started/quickstart) ·
+[Deploy the secure boundary](https://rookhold.vercel.app/getting-started/first-secure-deployment)
+
+## Add Rookhold to an application
+
+The **Rookhold SDK** is the client library for your code. It does not create a
+secure Linux execution boundary by itself; point it at a Rookhold service for
+untrusted workloads.
+
+### Python
 
 ```bash
-python -m pip install ./sdks/python
-cd sdks/typescript
-npm ci
-npm pack
+pip install rookhold
 ```
-
-After v0.8.0 is published, those become `pip install rookhold` and
-`npm install rookhold`.
 
 ```python
 from rookhold import Rookhold
@@ -42,669 +85,145 @@ result = Rookhold.from_env().run("python", "print(6 * 7)")
 print(result.stdout)
 ```
 
-Use Rookhold when an agent or user supplies short-lived code and you need it
-bounded, cancellable, and inspectable. It is not a persistent development
-workspace, browser sandbox, remote IDE, or general-purpose container platform.
+### TypeScript
 
-[Quickstart](https://rookhold.vercel.app/getting-started/quickstart) ·
-[Python](https://rookhold.vercel.app/use/python) ·
-[TypeScript](https://rookhold.vercel.app/use/typescript) ·
-[CLI](https://rookhold.vercel.app/use/cli) ·
-[MCP](https://rookhold.vercel.app/use/mcp) ·
-[Recipes](https://rookhold.vercel.app/use/recipes) ·
-[Self-hosting](https://rookhold.vercel.app/deployment) ·
-[Security model](https://rookhold.vercel.app/security-boundary) ·
-[API](https://rookhold.vercel.app/api)
-
-> [!WARNING]
-> With no configured endpoint, `rookhold run` manages an unisolated local
-> service for trusted code and reports `isolation: none` and `network: host`.
-> Use a dedicated Linux gVisor service for untrusted code.
-
-The memorable failure case is deliberate:
-
-```console
-$ rookhold run python 'while True: pass' --wall-seconds 2
-Job terminated after 2.00s
-
-status       timed_out
-wall limit   2s — enforced
-network      disabled
-isolation    gvisor-application-kernel
-receipt      saved to .rookhold/runs/019…/receipt.json
+```bash
+npm install rookhold
 ```
 
-Copyable applications live in [examples](examples/) and the forkable
-[Next.js](templates/nextjs-code-runner/) and
-[FastAPI](templates/fastapi-code-runner/) starters.
+```typescript
+import { Rookhold } from "rookhold";
 
-[![Rookhold terminating an infinite Python loop after two seconds and saving the execution receipt](docs/assets/rookhold-cli-mcp-demo.gif)](docs/assets/rookhold-cli-mcp-demo.mp4)
+const result = await Rookhold.fromEnv().run({
+  language: "python",
+  code: "print(6 * 7)",
+});
+console.log(result.stdout);
+```
+
+[Python guide](https://rookhold.vercel.app/use/python) ·
+[TypeScript guide](https://rookhold.vercel.app/use/typescript) ·
+[API reference](https://rookhold.vercel.app/api)
+
+## Connect to an existing Rookhold server
+
+The **Rookhold client** is the smallest download for a person or MCP host that
+already has a Rookhold endpoint. It does not include the local service.
+
+| Your computer | Standalone client |
+|---|---|
+| Windows, 64-bit | [Download the Windows client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-pc-windows-msvc.exe) |
+| Mac with Apple silicon | [Download the Mac client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin) |
+| Linux x86_64 | [Download the Linux client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu) |
+
+Run it normally for the operator terminal, or register the same file with the
+`mcp-server` argument in Claude Code, OpenCode, Hermes, or another MCP host.
+The model never chooses the service URL, API key, language allowlist, or
+required isolation class.
+
+```bash
+rookhold setup claude-code
+rookhold setup opencode
+rookhold setup hermes
+```
+
+Adding Rookhold does not disable a host's built-in shell or other execution
+tools. Remove or deny those routes when a model must cross only the Rookhold
+boundary.
+
+[CLI guide](https://rookhold.vercel.app/use/cli) ·
+[MCP guide](https://rookhold.vercel.app/use/mcp) ·
+[Integration templates](integrations/README.md)
 
 ## What Rookhold does
 
-Your agent—or any application—sends Rookhold a short job. Rookhold then:
+For every submitted job, Rookhold:
 
-1. checks who is asking and what they are allowed to do;
-2. applies server-controlled time and resource limits;
-3. runs the job using the configured execution boundary;
-4. streams the output into the operator console; and
-5. keeps a result and evidence record you can inspect later.
+1. authenticates the caller and checks admission policy;
+2. applies server-controlled time, memory, process, file, and output limits;
+3. runs the job using the configured execution provider;
+4. preserves bounded output, events, cancellation state, and artifacts; and
+5. records the effective runtime posture and receipt.
 
-You do **not** need to understand Rust or the Rookhold source code to use the
-prebuilt app. You only need a supported computer and a terminal. A self-hosted
-service also needs at least one job runtime, such as Python, Node.js, or Bash.
+The API and persisted store remain the source of truth. The CLI, SDKs, MCP
+adapter, and dashboard are views over the same contracts.
 
-## Download one CLI file
+## Three useful recipes
 
-Already have a Rookhold endpoint? Download one self-contained file—no archive,
-Python, `pip`, or source checkout. The same file opens the human terminal and
-runs the MCP server for Claude Code, OpenCode, and other agent CLIs.
+- [Run an LLM-generated function](examples/llm-tool-call/)—submit generated
+  source without evaluating it inside the agent process.
+- [Apply a user-defined JSON transform](examples/json-transform/)—send
+  structured input and read structured output.
+- [Grade code against hidden tests](examples/evaluator/)—bound evaluation time
+  and retain the result record.
 
-| Your computer | Single-file CLI |
-|---|---|
-| Windows, 64-bit | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe) |
-| Mac with Apple silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin) |
-| Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu) |
+[See every recipe](examples/README.md) or start from the
+[Next.js](templates/nextjs-code-runner/) and
+[FastAPI](templates/fastapi-code-runner/) examples.
 
-Run it normally for the interactive CLI. Register the same path plus the
-`mcp-server` argument in an MCP host. On macOS or Linux, mark the download
-executable once with `chmod +x ./rookhold-cli-*`. Rename it to `rookhold-cli`
-(`rookhold-cli.exe` on Windows) and place it on `PATH` for the copy-ready agent
-configurations to work unchanged.
+## Is Rookhold right for the task?
 
-## Keep the local development service running
-
-Use `rookhold run` for one job. Use this longer path only when you want the API
-and dashboard to remain available between runs. You do not need Rust or a
-source checkout.
-
-> [!WARNING]
-> This quick start is an **unisolated local demo for code you trust**. Keep it on
-> `127.0.0.1`; do not expose it to a network or use it for hostile code.
-
-### 1. Download the app
-
-Choose the complete app bundle for your computer:
-
-| Your computer | Download the complete app bundle |
-|---|---|
-| Windows, 64-bit | [Download the Windows app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-pc-windows-msvc.zip) |
-| Mac with Apple silicon | [Download the Mac app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-aarch64-apple-darwin.tar.gz) |
-| Linux x86_64 | [Download the Linux app](https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-x86_64-unknown-linux-musl.tar.gz) |
-
-Extract the archive. It contains the Rookhold service, `rookhold-cli`,
-`rookhold-mcp`, verification tools, and the copy-ready agent configurations.
-You do not need Python, Rust, or a separate SDK package to use the terminal
-apps. Rookhold automatically shows only the job runtimes that work on your
-machine.
-
-### 2. Start Rookhold
-
-Open a terminal in the extracted folder and run one of these commands.
-
-Windows PowerShell:
-
-```powershell
-$env:ROOKHOLD_SANDBOX = "off"
-$env:ROOKHOLD_JOBS_ROOT = Join-Path (Get-Location) ".rookhold-dev\jobs"
-.\rookhold.exe
-```
-
-macOS or Linux:
-
-```bash
-chmod +x rookhold rookhold-verify
-ROOKHOLD_SANDBOX=off ROOKHOLD_JOBS_ROOT="$PWD/.rookhold-dev/jobs" ./rookhold
-```
-
-Leave that terminal open. Rookhold is now running only on your computer.
-
-### 3. Use it from your terminal
-
-Point the included terminal app at the local service and open it.
-
-Windows PowerShell:
-
-```powershell
-$env:ROOKHOLD_BASE_URL = "http://127.0.0.1:7300"
-$env:ROOKHOLD_API_KEY = "rookhold-dev-key"
-.\rookhold-cli.exe
-```
-
-macOS or Linux:
-
-```bash
-ROOKHOLD_BASE_URL=http://127.0.0.1:7300 \
-ROOKHOLD_API_KEY=rookhold-dev-key \
-  ./rookhold-cli
-```
-
-The terminal shows the authenticated tenant, actual backend, observed
-isolation, required minimum, and live MCP tool count before accepting work.
-Try `/mcp`, then `/run python "print(6 * 7)"`. Type `/help` for jobs, results,
-events, cancellation, posture, and multiline paste commands.
-
-The included `QUICKSTART.md` repeats these commands next to the executables.
-If your operating system warns about an unidentified publisher, verify the
-archive against `SHA256SUMS` and the GitHub provenance before allowing it. The
-current community release is not yet backed by commercial Windows or Apple
-code-signing certificates.
-
-### 4. Or use the web console
-
-1. Open <http://127.0.0.1:7300>.
-2. Enter `rookhold-dev-key` in **API key**, then select **Apply**.
-3. Keep the included example or paste a short trusted script.
-4. Select **Queue run**.
-5. Watch the transcript, then open **Result & record**.
-
-The red `off · none` label is expected in this demo. It tells you honestly that
-the local process is **not sandboxed**.
-
-![Rookhold's Chalk-and-Carbon execution desk showing the docked composer, chronological transcript, and contextual result record](docs/assets/console-v0.6.png)
-
-### Console guide
-
-| Area | What it is for |
-|---|---|
-| **Compose** | Choose a language, paste code, and set simple limits. |
-| **History** | Reopen earlier jobs and see whether they succeeded. |
-| **Transcript** | Follow accepted policy, execution, output, completion, and proof in order. |
-| **Result & record** | Inspect the final outcome and download available evidence. |
-| **Runtime label** | See the isolation Rookhold actually observed—not just what was requested. |
-
-## Connect an AI agent
-
-Rookhold release-checks Claude Code, OpenCode, and Hermes through
-`rookhold-cli mcp-server`. Other MCP hosts can use the generic stdio contract.
-
-1. Start Rookhold using the demo above or the production deployment.
-2. Put the single-file `rookhold-cli` download in a stable path or keep the
-   extracted app folder where it is.
-3. Run `rookhold setup claude-code`, `rookhold setup opencode`, or
-   `rookhold setup hermes`. Review the diff and restart the host.
-
-Use the copy-ready guides for [Claude Code](integrations/claude-code/mcp.json),
-[OpenCode](integrations/opencode/opencode.snippet.json),
-[Hermes](integrations/hermes/config.snippet.yaml), or a
-[generic MCP host](integrations/README.md#generic-mcp-host). OpenClaw and other
-community host examples remain available but are not part of the release
-compatibility matrix. The detailed,
-fail-closed installation path is in [Agent and harness integration](#agent-and-harness-integration).
-
-## Is Rookhold right for my task?
-
-| Use Rookhold for | Keep using your agent's normal workspace for |
+| Use Rookhold for | Keep using the normal workspace for |
 |---|---|
 | short generated or user-supplied scripts | editing a repository |
 | stateless transforms, checks, and evaluators | persistent files and package installation |
-| work that needs limits, cancellation, or an evidence record | browsers, terminals, ports, and long-running services |
-| execution that must cross a separately operated API boundary | trusted work already isolated well enough by the agent |
+| jobs needing limits, cancellation, or evidence | browsers, ports, and long-running services |
+| execution behind a separately controlled API | trusted development already isolated well enough |
 
-Using both is normal. Your agent decides what work is needed; Rookhold independently
-decides whether and how a submitted job may run.
+Using both is normal. Rookhold owns short execution policy and evidence; it
+does not replace the rest of an agent or application runtime.
 
-## Before you run untrusted code
+## Before running untrusted code
 
-The quick start above is intentionally not a sandbox. For mutually untrusted
-jobs, use the guarded production profile on a dedicated Linux x86_64 VM and
-complete every deployment check.
+The guarded production profile is **Linux x86_64-only**. macOS, Windows, and
+other Linux architectures support only the unisolated same-trust development
+provider. Production uses a dedicated Linux x86_64 VM, pinned gVisor `runsc`, a
+private root filesystem, cgroup v2, scoped credentials, and non-skipping
+containment checks.
 
-> [!IMPORTANT]
-> The `gVisor` production profile is Linux x86_64-only. macOS, Windows, and other Linux architectures can run only the same-trust subprocess backend. The outer
-> Rookhold service is privileged even when each job uses gVisor, so it belongs on a
-> dedicated VM. Read [the security boundary](docs/security-boundary.md) before
-> accepting untrusted jobs.
+The service container has host-equivalent outer authority even though each job
+runs inside a separate gVisor workload. Do not place it on a shared
+multi-tenant Docker host.
 
-> [!NOTE]
-> **Current stable release:** [v0.7.1](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1).
-> The v0.8.0 source on `main` is validated but not yet tagged or published.
-> Its exact eleven-asset set includes checksums, a combined artifact-scoped SPDX
-> SBOM, GitHub SBOM/provenance attestations, and the offline `rookhold-verify`
-> verifier inside each platform archive. Older release lines are unsupported
-> for new deployments.
+[Read the security boundary](docs/security-boundary.md) before accepting
+untrusted jobs.
 
-### Upgrading from Coop
+## Documentation
 
-Rookhold is the new project name as of v0.6. Existing integrations do not need
-an all-at-once migration: the `coop` binaries, Python imports, TypeScript
-compatibility export, `coop-mcp` command, and `COOP_*` environment variables
-remain supported aliases. If both a `ROOKHOLD_*` and matching `COOP_*` variable
-are set to different non-empty values, startup fails instead of guessing.
+- [Getting started](https://rookhold.vercel.app/getting-started/quickstart)
+- [Installation choices](https://rookhold.vercel.app/getting-started/installation)
+- [Execution model](https://rookhold.vercel.app/understand/execution-model)
+- [Receipts and verification](https://rookhold.vercel.app/understand/receipts)
+- [Deployment and operations](https://rookhold.vercel.app/deployment)
+- [Compatibility](https://rookhold.vercel.app/compatibility)
+- [Release process](docs/releasing.md)
 
-The `/v1` API, `application/vnd.coop...` media types, `coop://` evidence subject
-names, and v1 predicate URI are unchanged because they are durable wire and
-signature identities. See the [v0.6 upgrade guide](docs/upgrading.md#from-v05x-to-v060)
-for service files, paths, and rollback details.
+## Contributing
 
-## Why Rookhold exists
+Start with [CONTRIBUTING.md](CONTRIBUTING.md). The repository separates:
 
-Most agent sandboxes protect a development workspace. Rookhold adds a separately
-operated execution boundary for short, risky, or user-supplied jobs without
-letting the model hold the Rookhold key or choose its own server, tenant, language
-allowlist, or required isolation posture.
+- **Tier A**—docs, examples, and integrations;
+- **Tier B**—SDK, CLI, and public API work; and
+- **Tier C**—authentication, execution, storage, receipts, and isolation.
 
-Without Rookhold, a tool call often ends as `subprocess.run(model_text)` inside the
-agent process or a long-lived container. The application then has to invent
-authentication, resource ceilings, cancellation, output bounds, tenant
-concurrency, reconnectable streaming, and an audit record.
+Tier A changes should not inherit security-core ceremony. Tier C changes must
+prove the root invariant, regression, adversarial cases, and final exact-head
+validation.
 
-With Rookhold, the trusted adapter submits once and receives a job ID. Operators
-can answer five concrete questions: what ran, who submitted it, which controls
-actually became effective, what output or violations were observed, and how
-the run ended. Evidence survives failure, timeout, OOM, and cancellation.
+## Build from source
 
-```text
-you → AI agent or app → rookhold-cli mcp-server or SDK → Rookhold → short job
-       decides what      submits safely                 policy + evidence
-```
-
-### What ships
-
-- a one-command `rookhold run` path with live output, direct limit summaries, and saved receipts
-- standalone `rookhold-cli` and `rookhold-mcp` executables in every platform archive—no Python installation required
-- one authenticated HTTP API for submit, inspect, cancel, wait, and event history
-- live WebSocket output with one-use stream tickets and persisted history before live frames
-- scoped indexed credentials or RFC 9068 JWTs, with legacy per-tenant keys retained for migration
-- fair per-tenant admission, aggregate memory limits, logical storage quotas, and a disk-reserve watermark
-- server-clamped wall-time, CPU, memory, process, and file limits
-- bounded per-job input files, exact requested output artifacts, safe paths, and receipt hashes
-- versioned stdlib/base runtime-pack names bound to runtime and rootfs digests
-- a per-job gVisor OCI provider plus the Linux x86_64 namespace fallback, both with networking denied
-- an operator dashboard served from the binary
-- a SQLite schema-v4 job/evidence store with configurable retention, idempotent submission, and per-job hash chains
-- terminal evidence receipts binding policy, runtime posture, output digests, outcome, and chain head
-- Ed25519-signed DSSE/in-toto envelopes, exact result artifacts, restart backfill, and offline verification
-- bounded OpenMetrics telemetry plus W3C Trace Context correlation
-- stdlib-only Python and dependency-free TypeScript clients
-- a dependency-free `rookhold-cli` interactive terminal and one-shot operator client
-- a dependency-free, concurrent MCP mode in the same `rookhold-cli` file, plus the `rookhold-mcp` compatibility entry point
-
-The event chain remains server-verifiable operational evidence. A signed envelope additionally proves that the configured Rookhold key asserted the authoritative tenant, exact receipt, and result digest. It does **not** prove deterministic re-execution, trusted hardware, remote attestation, or WORM storage; distribute or pin the public key out of band rather than trusting its API `key_id` hint.
-
-## Common questions
-
-| Question | Answer |
-|---|---|
-| Do I need Rust? | **No.** Download a prebuilt release unless you want to contribute to Rookhold itself. |
-| Do I need an AI model? | **No.** Any application can call Rookhold through HTTP or an SDK. |
-| Can I use Claude Code, OpenCode, Codex, Hermes, or OpenClaw? | **Yes.** They can all launch the included stdio MCP adapter. |
-| Does Rookhold replace my agent's normal workspace? | **No.** Keep repository editing in the workspace and send short execution jobs to Rookhold. |
-| Is the automatic local run safe for untrusted code? | **No.** It is loopback-only and unisolated. Use the guarded production deployment for mutually untrusted jobs. |
-
-## Build from source (optional)
-
-Most users should use the [one-command quickstart](https://rookhold.vercel.app/getting-started/quickstart).
-This section is only for contributors or operators who specifically want to
-compile Rookhold themselves. Install Rust 1.98 and the runtimes you intend to use:
+Prebuilt releases are the normal path. Contributors need Rust 1.98 and the job
+runtimes they intend to test:
 
 ```bash
 git clone https://github.com/sambai-dev/rookhold.git
 cd rookhold
-ROOKHOLD_SANDBOX=off \
-ROOKHOLD_JOBS_ROOT="$PWD/.rookhold-dev/jobs" \
-cargo run --locked -p coop-server --bin rookhold
+cargo build --locked --workspace
 ```
 
-PowerShell:
-
-```powershell
-git clone https://github.com/sambai-dev/rookhold.git
-Set-Location rookhold
-$env:ROOKHOLD_SANDBOX = "off"
-$env:ROOKHOLD_JOBS_ROOT = Join-Path (Get-Location) ".rookhold-dev\jobs"
-cargo run --locked -p coop-server --bin rookhold
-```
-
-Open <http://127.0.0.1:7300>. Development mode uses the public local key
-`rookhold-dev-key` if `ROOKHOLD_API_KEYS` is unset. The explicit `off` setting uses an
-**unisolated subprocess**. Do not expose it or submit code you do not trust.
-
-At startup, development mode runs a bounded canary under the same sanitized
-environment used for jobs. `/v1/capabilities` advertises only runtimes that
-passed, and submissions for an unavailable runtime fail with
-`422 runtime_unavailable`. The resolved executable is cached for the process,
-so admission and execution use the same runtime path.
-
-## Production on a dedicated Linux x86_64 VM
-
-The supplied Compose deployment includes a purpose-built private rootfs and
-uses one pinned gVisor workload per job. On a fresh dedicated VM, one guarded
-command provisions the tenant credential, reviewed `runsc` binary, and local
-Ed25519 signing key; builds the image; binds the exact rootfs-manifest digest;
-starts the service; and runs receipt-and-attestation-checked canaries in every
-runtime:
-
-```bash
-ROOKHOLD_PRODUCTION_VM_ACKNOWLEDGED=true scripts/bootstrap-production.sh
-```
-
-The bootstrap creates `.env` and `.coop-runtime/` with owner-only permissions
-and never replaces existing credentials or private key material. It also
-derives `.coop-runtime/attestation-public-key.pem` locally as the explicit
-operator trust pin. The image entrypoint stages the host-owned key and `runsc`
-into root-owned container-local paths before Rookhold starts, preserving the
-strict ownership boundary of a rootful deployment. On later runs the bootstrap
-validates the exact staged runtime/key and existing pin, updates the rootfs
-digest, deploys, and repeats the same production verifier with the packaged
-`rookhold-verify`. The acknowledgement is deliberate: it does not make the
-privileged outer service safe on a general-purpose host.
-
-Compose is loopback-only. Each submitted job crosses its own gVisor application-kernel boundary, but `privileged: true` still gives the **outer Rookhold container** host-equivalent authority for runtime and cgroup setup. Use this configuration only inside a dedicated, disposable x86_64 VM. It is not a safe control-plane deployment on a general-purpose Docker host. See [deployment choices](docs/deployment.md).
-
-Production is more involved because the private rootfs, cgroup delegation,
-reviewed runtime, signing key, tenant identity, TLS/private ingress, and
-hostile canary are the security boundary—not optional setup noise. The
-deployment guide separates the one-time VM prerequisites from the repeatable
-Compose start and provides the exact posture assertions required before
-traffic is admitted.
-
-## Run a job
-
-Set the client key for the path you started: use the public development key only for the loopback local-development process, or use the random key portion you placed after `tenant:` in `.env` for Compose.
-
-```bash
-ROOKHOLD_CLIENT_KEY="${ROOKHOLD_CLIENT_KEY:-rookhold-dev-key}"
-curl --fail-with-body -X POST http://127.0.0.1:7300/v1/jobs \
-  -H "Authorization: Bearer $ROOKHOLD_CLIENT_KEY" \
-  -H 'Idempotency-Key: readme-python-42-v1' \
-  -H 'Content-Type: application/json' \
-  --data '{
-    "language": "python",
-    "code": "print(6 * 7)",
-    "requirements": {"minimum_isolation": "gvisor-application-kernel"},
-    "limits": {"wall_seconds": 10, "mem_mb": 256}
-  }'
-```
-
-Use `minimum_isolation: "none"` only with the explicitly unisolated local
-quick start. A reused idempotency key returns the original job only when the
-canonical request is identical; reuse with different code or policy fails.
-
-The response contains a UUIDv7 `job_id`. Use it in the following requests:
-
-```bash
-curl --fail-with-body \
-  -H "Authorization: Bearer $ROOKHOLD_CLIENT_KEY" \
-  'http://127.0.0.1:7300/v1/jobs/JOB_ID/result?wait_seconds=60'
-
-curl --fail-with-body \
-  -H "Authorization: Bearer $ROOKHOLD_CLIENT_KEY" \
-  http://127.0.0.1:7300/v1/jobs/JOB_ID/replay
-
-stream_response=$(curl --fail-with-body -X POST \
-  -H "Authorization: Bearer $ROOKHOLD_CLIENT_KEY" \
-  http://127.0.0.1:7300/v1/jobs/JOB_ID/stream-ticket)
-stream_path=$(printf '%s' "$stream_response" | \
-  python -c 'import json, sys; print(json.load(sys.stdin)["stream_url"])')
-websocat "ws://127.0.0.1:7300${stream_path}"
-```
-
-After a terminal job's `attestation.available` becomes `true`, download the
-exact signed envelope and result artifact, then verify them with a public key
-you obtained through a trusted operator channel:
-
-```bash
-curl --fail-with-body -H "Authorization: Bearer $ROOKHOLD_CLIENT_KEY" \
-  -o job.dsse.json http://127.0.0.1:7300/v1/jobs/JOB_ID/attestation
-curl --fail-with-body -H "Authorization: Bearer $ROOKHOLD_CLIENT_KEY" \
-  -o job-result.json http://127.0.0.1:7300/v1/jobs/JOB_ID/result-artifact
-rookhold-verify verify \
-  --envelope job.dsse.json \
-  --subject job-result.json \
-  --public-key rookhold-attestation.pub.pem \
-  --tenant TENANT_ID
-```
-
-`/v1/attestation/public-key` exposes the current public key for discovery, but
-its own trust notice is important: fetching a key from the same server is not
-independent key distribution. The predicate and exact result both bind the
-authoritative tenant; pass the tenant expected by your workflow to
-`rookhold-verify` rather than trusting a value copied from downloaded JSON.
-
-PowerShell local-development equivalent:
-
-```powershell
-$headers = @{ Authorization = "Bearer rookhold-dev-key" }
-$body = @{
-    language = "python"
-    code = "print(6 * 7)"
-    requirements = @{ minimum_isolation = "none" }
-    limits = @{ wall_seconds = 10; mem_mb = 256 }
-} | ConvertTo-Json -Depth 3
-$job = Invoke-RestMethod -Method Post -Headers $headers `
-    -ContentType "application/json" -Body $body `
-    -Uri "http://127.0.0.1:7300/v1/jobs"
-$result = Invoke-RestMethod -Headers $headers `
-    -Uri "http://127.0.0.1:7300/v1/jobs/$($job.job_id)/result?wait_seconds=60"
-$result
-```
-
-Prefer `/result` to status polling. Resume replay and WebSocket streams from the last accepted cursor after a transport close. Do not automatically retry a timed-out submission because it may already have committed; see [API and streaming](docs/api.md) for the complete transport contract.
-
-## Execution lifecycle
-
-```text
-accepted → queued → running → succeeded
-                            ↘ failed
-                            ↘ timed_out
-                            ↘ oom_killed
-                            ↘ cancelled
-                            ↘ error
-```
-
-Each job has an ordered event history. A client that joins the WebSocket after execution began receives persisted events first and then live events. Output is bounded; truncation is recorded rather than allowing an unbounded server-memory or database write path.
-
-## API and clients
-
-OpenAPI is served at `/openapi.json`. The core routes are:
-
-| Method | Path | Purpose |
-|---|---|---|
-| `POST` | `/v1/jobs` | Submit a job |
-| `GET` | `/v1/jobs` | Cursor-list the authenticated tenant's jobs |
-| `GET` | `/v1/jobs/{id}` | Inspect status, requested/effective policy, and terminal receipt |
-| `DELETE` | `/v1/jobs/{id}` | Cancel a queued or running job |
-| `GET` | `/v1/jobs/{id}/result` | Wait for and fold an outcome |
-| `GET` | `/v1/jobs/{id}/attestation` | Download the exact persisted DSSE envelope |
-| `GET` | `/v1/jobs/{id}/result-artifact` | Download the exact result bytes authenticated by that envelope |
-| `GET` | `/v1/jobs/{id}/replay` | Cursor-read ordered persisted events |
-| `GET` | `/v1/jobs/{id}/stream` | WebSocket history plus live events |
-| `POST` | `/v1/jobs/{id}/stream-ticket` | Mint a short-lived, one-use, job-bound stream credential |
-| `GET` | `/v1/status` | Authenticated build and sandbox posture |
-| `GET` | `/v1/capabilities` | Supported languages, limits, and server features |
-| `GET` | `/v1/attestation/public-key` | Discover the current signer key and explicit trust warning |
-| `GET` | `/v1/whoami` | Resolve the current principal, tenant, scopes, and authority lifetime |
-| `GET` | `/v1/metrics` | Prometheus-format process/job metrics |
-| `GET` | `/healthz` | Unauthenticated liveness only |
-| `GET` | `/readyz` | Unauthenticated process/store readiness; still verify authenticated posture |
-
-See [API and streaming](docs/api.md) and [SDK usage](docs/sdks.md). The dashboard uses the same API; it is an operator surface, not a separate source of truth.
-
-## Agent and harness integration
-
-The same single-file `rookhold-cli` download starts MCP mode with
-`mcp-server`. It exposes four narrow tools—run, result, events, and
-cancel—while keeping credentials and policy in the trusted adapter process.
-It supports the stateless MCP 2026 discovery and opt-in Tasks contract while
-retaining the legacy initialize flow. Concurrent stdio requests remain
-responsive, cancellation is durable, and a timed-out wait returns the job ID
-instead of losing ownership of the still-running job.
-
-### Connect a harness
-
-1. Start Rookhold locally or deploy it on the dedicated VM.
-2. Download and verify the single `rookhold-cli-*` file for the harness host,
-   then put it at a stable absolute path. No Python environment is needed.
-
-3. Give the harness process—not the model—the connection and policy settings:
-
-   ```dotenv
-   ROOKHOLD_BASE_URL=https://rookhold.internal.example
-   ROOKHOLD_API_KEY=replace-with-the-key-only
-   ROOKHOLD_MCP_MINIMUM_ISOLATION=gvisor-application-kernel
-   ROOKHOLD_MCP_ALLOWED_LANGUAGES=python,node
-   ```
-
-4. Point the harness's stdio MCP configuration at the downloaded
-   `rookhold-cli` file with `mcp-server` as its argument, merge the matching
-   snippet below, and restart or reload the harness.
-
-On Windows, keep the downloaded `.exe` extension.
-`ROOKHOLD_MCP_MINIMUM_ISOLATION` may be omitted or set to `none` only for the
-explicitly unisolated local demo. Production integrations should specify the
-exact minimum isolation class and fail closed.
-
-Copy-ready configuration is included for:
-
-- [Claude Code](integrations/claude-code/mcp.json)
-- [OpenCode v2](integrations/opencode/opencode.snippet.json)
-- [Hermes](integrations/hermes/config.snippet.yaml)
-- [OpenClaw](integrations/openclaw/openclaw.snippet.json5)
-- [generic MCP hosts](integrations/README.md#generic-mcp-host)
-
-Adding Rookhold does not disable an agent's existing `exec`, terminal, or native
-code-execution tool. Deny those alternate routes when policy requires every
-generated job to pass through Rookhold. See [integration architecture and the
-production checklist](docs/integrations.md).
-
-## Configuration
-
-| Variable | Default | Notes |
-|---|---|---|
-| `ROOKHOLD_ADDR` | `127.0.0.1:7300` | Listen address; keep private or place behind TLS |
-| `ROOKHOLD_DB` | `rookhold.db` | SQLite database path; an existing `coop.db` is adopted when the new default does not exist |
-| `ROOKHOLD_API_KEYS` | dev key outside production | Comma-separated `tenant:key` entries; production rejects blank, short, and public keys |
-| `ROOKHOLD_CREDENTIALS_FILE` + `ROOKHOLD_CREDENTIAL_PEPPER_FILE` | unset | Indexed, peppered HMAC credentials with principal, scopes, expiry, and revocation; preferred over legacy keys |
-| `ROOKHOLD_OIDC_ISSUER`, `ROOKHOLD_OIDC_AUDIENCE`, `ROOKHOLD_OIDC_JWKS_URL`, `ROOKHOLD_OIDC_TENANT_MAP` | unset | Strict RFC 9068 JWT authority and tenant mapping; all core values are required together |
-| `ROOKHOLD_METRICS_TOKEN` | unset | Separate operator credential for global `/metrics`; never accepted as a tenant credential |
-| `ROOKHOLD_ENV` | unset | `prod`, `production`, or `release` enables fail-closed production checks |
-| `NODE_ENV` | unset | Compatibility alias: `prod`, `production`, or `release` also enables the same production checks |
-| `ROOKHOLD_SANDBOX` | `auto` | `gvisor`, `ns`, `auto`, or `off`; production does not silently downgrade and Compose defaults to `gvisor` |
-| `ROOKHOLD_ROOTFS` | unset | Required private rootfs for gVisor and namespaces; `/` is rejected |
-| `ROOKHOLD_SANDBOX_HELPER` | sibling `rookhold-sandbox-init` | Dedicated single-threaded Linux x86_64 bootstrap helper; package and version it with `rookhold` |
-| `ROOKHOLD_GVISOR_RUNSC` | unset | Absolute path to the reviewed `runsc` binary |
-| `ROOKHOLD_GVISOR_ROOTFS_SHA256` | unset | SHA-256 of the exact `/.coop-rootfs.manifest`; required in gVisor mode |
-| `ROOKHOLD_GVISOR_PLATFORM` | `systrap` | Reviewed gVisor platform (`systrap`, or `kvm` on a separately reviewed host) |
-| `ROOKHOLD_ATTESTATION_MODE` | `off` in development; signing required in production | `sign` or explicit `off` |
-| `ROOKHOLD_ATTESTATION_KEY_FILE` | unset | Strict Ed25519 PKCS#8 key; required for signing and must be absolute in production |
-| `ROOKHOLD_UNSAFE_ALLOW_NAIVE` | false | Required acknowledgement for an explicit unisolated production-mode process |
-| `ROOKHOLD_SECCOMP` | `auto` | Namespace syscall filter; cannot be disabled in production |
-| `ROOKHOLD_JOBS_ROOT` | `/var/lib/rookhold/jobs` on Linux | Dedicated absolute non-symlink staging directory |
-| `ROOKHOLD_WORKERS` | `4` | Worker count |
-| `ROOKHOLD_TENANT_CONCURRENCY` | `2` | Concurrent jobs per tenant |
-| `ROOKHOLD_TENANT_QUEUE_CAPACITY` | `64` | Durable accepted-but-queued jobs per tenant |
-| `ROOKHOLD_MAX_JOB_MEM_MB` / `ROOKHOLD_MEMORY_BUDGET_MB` | `1024` / `4096` | Per-job ceiling and weighted aggregate in-flight memory budget |
-| `ROOKHOLD_STORAGE_TENANT_MB` / `ROOKHOLD_STORAGE_GLOBAL_MB` | `4096` / `16384` | Transactional logical retained-data quotas |
-| `ROOKHOLD_STORAGE_FREE_RESERVE_MB` | `1024` | Filesystem free-space watermark below which growth fails closed |
-| `ROOKHOLD_RATE_PER_MIN` | `120` | Requests per minute per tenant |
-| `ROOKHOLD_RETENTION_HOURS` | `168` | Terminal-job retention; `0` disables deletion |
-| `ROOKHOLD_SWEEP_INTERVAL_SECS` | `3600` | Retention sweep interval, minimum 60 |
-| `ROOKHOLD_PYTHON`, `ROOKHOLD_NODE`, `ROOKHOLD_BASH` | `PATH` lookup | Interpreter overrides; paths must exist in the private rootfs too |
-| `RUST_LOG` | `info` | Rust tracing filter |
-
-Requested limits are clamped to compiled ceilings before execution, but
-"requested" is not the same as "enforced." The gVisor and namespace providers
-enforce the clamped wall-time, CPU, memory, process, and file controls. The
-unisolated development subprocess enforces only wall time; its CPU, memory,
-process, and file values are `null` in effective policy and their
-`limit_enforcement` flags are `false`. `allow_network` is not an egress opt-in
-in the current release: both isolated providers deny job networking, while the
-development backend retains the service account's host networking and reports
-`networking: "host"` after the workload reaches its ready boundary.
-
-## Repository map
-
-| Path | Responsibility |
-|---|---|
-| `crates/coop-types` | API types, statuses, and limit ceilings |
-| `crates/coop-store` | SQLite jobs, events, quotas, signing outbox, and exact attestation artifacts |
-| `crates/coop-exec` | development, Linux namespace, and per-job gVisor OCI providers |
-| `crates/coop-attestation` | DSSE/in-toto profile, Ed25519 keys, and `rookhold-verify` |
-| `crates/coop-server` | API, fair scheduler, identity, observability, signer, dashboard, and OpenAPI |
-| `sdks` | Python and TypeScript clients |
-| `integrations` | MCP templates for Claude Code, OpenCode, Hermes, OpenClaw, and generic hosts |
-| `hostile-jobs` | adversarial payloads used by containment verification |
-| `crates/coop-server/tests/hostile.rs` | containment harness and invariant assertions |
-| `docs` | architecture, boundary, API, deployment, and operations |
-| `PRODUCT.md` | durable users, purpose, positioning, and product constraints |
-| `DESIGN.md` | operator-console tokens, responsive rules, and component language |
-
-The `coop-*` crate and compatibility filenames are intentional durable internal,
-wire, and evidence identities retained across the public rename; new user-facing
-interfaces use Rookhold names.
-
-## Verification
-
-```bash
-cargo fmt --all --check
-cargo clippy --locked --workspace --all-targets -- -D warnings
-cargo test --locked --workspace --all-targets
-python scripts/check-release-surface.py
-python -m pip install --no-deps ./sdks/python
-python -m unittest discover -s sdks/python/tests -v
-cd sdks/typescript
-npm ci
-npm test
-npm run typecheck
-```
-
-Containment tests and isolated providers are Linux x86_64-only. Namespace tests require Linux 5.14+, `cgroup.kill`, recursive `mount_setattr`, root, cgroup v2, the matching helper, and a trusted private rootfs. The gVisor gate additionally uses the exact reviewed `runsc`, rootfs manifest, OCI init, and lifecycle/crash tests. Run from a root-owned test environment with Rust 1.98:
-
-```bash
-sudo env \
-  ROOKHOLD_ROOTFS=/opt/rookhold/rootfs \
-  ROOKHOLD_SANDBOX_HELPER=/usr/local/bin/rookhold-sandbox-init \
-  cargo test --locked -p coop-server --test hostile -- --ignored --nocapture
-
-sudo env \
-  ROOKHOLD_GVISOR_RUNSC=/usr/local/bin/runsc \
-  ROOKHOLD_GVISOR_SERVER_BIN=target/debug/rookhold \
-  bash scripts/smoke-gvisor.sh
-```
-
-A successful unit test run on macOS, Windows, or another Linux architecture is not evidence that Linux x86_64 containment works. Those platforms use the unisolated development subprocess backend only. Release CI constructs an ephemeral x86_64 private rootfs, expects exactly 18 hostile tests, checks every prerequisite, and fails if the suite cannot run or reports a skip.
-
-## Documentation
-
-- [Architecture](docs/architecture.md)
-- [Security boundary and trust tiers](docs/security-boundary.md)
-- [API and streaming](docs/api.md)
-- [SDKs](docs/sdks.md)
-- [Terminal clients](docs/cli.md)
-- [Agent and harness integrations](docs/integrations.md)
-- [Deployment](docs/deployment.md)
-- [Operations, backup, and restore](docs/operations.md)
-- [Upgrading](docs/upgrading.md)
-- [Releasing](docs/releasing.md)
-- [Contribution lifecycle and exact-head evidence](docs/contribution-lifecycle.md)
-- [Troubleshooting](docs/troubleshooting.md)
-- [Security policy](SECURITY.md)
-- [Security review record](AUDIT.md)
-- [Changelog](CHANGELOG.md)
-
-Runnable starting templates for systemd, its environment file, and Caddy live under [`deploy/`](deploy/).
-
-## Contributing
-
-Questions and showcases belong in [Discussions](https://github.com/sambai-dev/rookhold/discussions). Bugs and scoped work belong in [Issues](https://github.com/sambai-dev/rookhold/issues). [CONTRIBUTING.md](CONTRIBUTING.md) separates docs/examples, SDK/API, and security-core changes so each contribution runs checks proportional to its risk.
-
-## Project direction
-
-Roadmap order follows developer outcomes:
-
-1. **Installable:** public PyPI and npm packages, one-command local run, plain-language checks, executable quickstarts, and Discussions.
-2. **Embeddable:** one-call Python and TypeScript APIs, structured results, maintained MCP setup, recipes, and forkable starters.
-3. **Useful for real jobs:** bounded files, returned artifacts, immutable runtime packs, and receipt-first verification.
-4. **Community-tested:** independent projects, external contributors, compatibility policy, and APIs stabilized from observed use.
-
-External KMS/HSM custody, transparency anchoring, credential brokerage,
-confidential VMs, cloud control planes, broad Kubernetes automation, persistent
-workspaces, browsers, desktops, billing, SSO, and large RBAC systems are paused
-until real users pull Rookhold there. Minor releases package meaningful
-developer outcomes; patch releases fix defects; uncertain contracts use
-prereleases. A 1.0 requires external use, not internal completeness.
+Run the complete checks from [CONTRIBUTING.md](CONTRIBUTING.md) before opening a
+pull request.
 
 ## License
 
-[MIT](LICENSE)
+Rookhold is released under the [MIT License](LICENSE).

--- a/crates/coop-server/src/cli.rs
+++ b/crates/coop-server/src/cli.rs
@@ -315,6 +315,7 @@ async fn run_once(args: RunArgs) -> Result<(), String> {
         .unwrap_or(configured_isolation);
     let code = read_code(&args.code)?;
     let mut limits = serde_json::Map::new();
+    limits.insert("allow_network".into(), json!(false));
     if let Some(value) = args.wall_seconds {
         limits.insert("wall_seconds".into(), json!(value));
     }
@@ -326,9 +327,7 @@ async fn run_once(args: RunArgs) -> Result<(), String> {
         "code": code,
         "requirements": {"minimum_isolation": minimum_isolation},
     });
-    if !limits.is_empty() {
-        body["limits"] = Value::Object(limits);
-    }
+    body["limits"] = Value::Object(limits);
     if let Some(stdin) = args.stdin {
         body["stdin"] = json!(stdin);
     }

--- a/crates/coop-server/src/cli.rs
+++ b/crates/coop-server/src/cli.rs
@@ -266,7 +266,7 @@ impl TemporaryServer {
                 ));
             }
             if client
-                .get(format!("{base_url}/healthz"))
+                .get(format!("{base_url}/readyz"))
                 .send()
                 .await
                 .is_ok_and(|response| response.status().is_success())

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -8,7 +8,7 @@ const siteOrigin = isVercel
 
 export default defineConfig({
   title: "Rookhold",
-  description: "A controlled execution boundary for AI agents, with hard limits, live output, and verifiable receipts.",
+  description: "Run short-lived Python, Node, and Bash code with hard limits and verifiable receipts.",
   lang: "en-US",
   base: siteBase,
   cleanUrls: true,
@@ -20,7 +20,7 @@ export default defineConfig({
     ["link", { rel: "icon", type: "image/svg+xml", href: `${siteBase}rook.svg` }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:title", content: "Rookhold" }],
-    ["meta", { property: "og:description", content: "Run agent code behind a boundary you control." }],
+    ["meta", { property: "og:description", content: "Run short-lived code with hard limits—and keep a receipt." }],
     ["meta", { property: "og:image", content: `${siteOrigin}/social-card.png` }],
     ["meta", { property: "og:url", content: `${siteOrigin}/` }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
@@ -34,7 +34,7 @@ export default defineConfig({
       { text: "MCP", link: "/use/mcp" },
       { text: "Security", link: "/security-boundary" },
       { text: "Deploy", link: "/deployment" },
-      { text: "Download", link: "/#download" },
+      { text: "Try locally", link: "/#try" },
     ],
     sidebar: {
       "/getting-started/": [

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -57,6 +57,8 @@ body { background: #fdfeff; }
 .VPButton { min-height: 44px; padding-inline: 20px !important; border-radius: 4px !important; }
 .VPButton.alt { background: #fff !important; border-color: #c8cdd6 !important; color: #111827 !important; }
 .VPButton.alt:hover { background: #f5f6f9 !important; border-color: #9ca3af !important; }
+.VPHero .actions .action:nth-child(3) .VPButton { background: transparent !important; border-color: transparent !important; color: #1e55e6 !important; }
+.VPHero .actions .action:nth-child(3) .VPButton:hover { background: #edf2ff !important; }
 
 .vp-doc div[class*=language-] { border-radius: 4px; }
 .VPHome .VPContent { overflow: hidden; }
@@ -79,19 +81,22 @@ body { background: #fdfeff; }
 .section-heading { max-width: 700px; }
 .section-heading > p:last-child { max-width: 650px; margin-top: 16px; font-size: 17px; line-height: 1.65; }
 
-.home-proof { display: grid; grid-template-columns: repeat(3, 1fr); padding-bottom: 80px; }
-.home-proof p {
+.home-use-cases { display: grid; grid-template-columns: repeat(3, 1fr); padding-bottom: 80px; }
+.home-use-cases a {
   display: flex;
   flex-direction: column;
   gap: 6px;
   margin: 0;
   padding: 17px 20px;
+  color: #111827;
   border: 1px solid #e1e4e9;
   border-right: 0;
+  text-decoration: none;
 }
-.home-proof p:last-child { border-right: 1px solid #e1e4e9; }
-.home-proof strong { color: #5e6675; font-size: 12px; font-weight: 650; text-transform: uppercase; }
-.home-proof span { color: #111827; font: 600 13px/1.4 var(--vp-font-family-mono); }
+.home-use-cases a:last-child { border-right: 1px solid #e1e4e9; }
+.home-use-cases a:hover { background: #f5f6f9; color: #1e55e6; }
+.home-use-cases strong { font-size: 15px; font-weight: 700; }
+.home-use-cases span { color: #5e6675; font-size: 13px; line-height: 1.5; }
 
 .home-demo {
   display: grid;
@@ -115,6 +120,7 @@ body { background: #fdfeff; }
 }
 .terminal-head { display: flex; justify-content: space-between; padding: 13px 16px; color: #9da7b5; border-bottom: 1px solid #29323e; }
 .terminal-head span:last-child { color: #7dd89b; }
+.terminal-head span.local-caution { color: #f4bd6a; }
 .terminal-line { display: flex; gap: 14px; padding: 24px 22px; color: #f7f9fc; border-bottom: 1px solid #29323e; font-size: 13px; }
 .terminal-line .prompt { color: #79a0ff; }
 .terminal-event { display: grid; grid-template-columns: 34px 138px minmax(0, 1fr); gap: 10px; padding: 18px 22px; border-bottom: 1px solid #29323e; }
@@ -144,22 +150,20 @@ body { background: #fdfeff; }
 .download-option strong { font-size: 18px; letter-spacing: -.02em; }
 .download-compatibility { max-width: 720px; margin-top: 14px; font-size: 13px; line-height: 1.55; }
 
-.mcp-section { padding-block: 82px !important; }
-.mcp-layout { display: grid; grid-template-columns: 1.08fr .92fr; gap: 56px; align-items: center; margin-top: 38px; }
-.mcp-code { overflow: hidden; background: #12171e; color: #e7ebf1; border: 1px solid #29323e; }
-.mcp-code-head { display: flex; justify-content: space-between; padding: 12px 16px; color: #9da7b5; border-bottom: 1px solid #29323e; font: 11px/1.4 var(--vp-font-family-mono); }
-.mcp-code pre { margin: 0; padding: 22px; overflow: auto; background: transparent; font-size: 13px; line-height: 1.7; }
-.mcp-code code { color: #e7ebf1; }
-.mcp-steps { margin: 0 !important; padding: 0 !important; list-style: none; }
-.mcp-steps li { display: grid; grid-template-columns: 34px 1fr; gap: 14px; padding: 17px 0; border-bottom: 1px solid #e1e4e9; }
-.mcp-steps li:first-child { border-top: 1px solid #e1e4e9; }
-.mcp-steps li > span { color: #1e55e6; font: 700 12px/1.4 var(--vp-font-family-mono); }
-.mcp-steps strong { color: #111827; font-size: 15px; }
-.mcp-steps p { margin: 4px 0 0; line-height: 1.55; }
-.host-links { display: grid; grid-template-columns: repeat(4, 1fr); margin-top: 28px; border: 1px solid #e1e4e9; }
-.host-links a { padding: 13px 16px; color: #111827; border-right: 1px solid #e1e4e9; text-align: center; text-decoration: none; }
-.host-links a:last-child { border-right: 0; }
-.host-links a:hover { color: #1e55e6; background: #f5f6f9; }
+.sdk-section { padding-block: 82px !important; }
+.sdk-layout { display: grid; grid-template-columns: repeat(2, 1fr); margin-top: 36px; border: 1px solid #29323e; }
+.install-command { display: grid; gap: 14px; padding: 24px; background: #12171e; color: #e7ebf1; }
+.install-command:first-child { border-right: 1px solid #29323e; }
+.install-command > span { color: #9da7b5; font-size: 12px; font-weight: 650; }
+.install-command code { color: #f7f9fc; background: transparent; font-size: 15px; }
+.install-command a { color: #79a0ff; font-size: 13px; text-decoration: none; }
+.install-command a:hover { text-decoration: underline; text-underline-offset: 4px; }
+
+.client-section { display: grid; grid-template-columns: 1fr .9fr; gap: 72px; align-items: center; padding-block: 82px !important; border-top: 1px solid #e1e4e9; }
+.client-links { display: grid; border: 1px solid #c8cdd6; }
+.client-links a { padding: 16px 18px; color: #111827; border-bottom: 1px solid #e1e4e9; text-decoration: none; }
+.client-links a:last-child { border-bottom: 0; }
+.client-links a:hover { color: #1e55e6; background: #f5f6f9; }
 
 .boundary-section {
   display: grid;
@@ -189,11 +193,8 @@ body { background: #fdfeff; }
   .VPHero { padding-top: 64px !important; }
   .VPHero .image-container { width: 190px; height: 190px; }
   .VPHero .image-src { width: 190px; height: 190px; }
-  .home-demo, .mcp-layout, .boundary-section, .faq-section { grid-template-columns: 1fr; gap: 34px; }
+  .home-demo, .client-section, .boundary-section, .faq-section { grid-template-columns: 1fr; gap: 34px; }
   .home-demo-copy { max-width: 650px; }
-  .host-links { grid-template-columns: repeat(2, 1fr); }
-  .host-links a:nth-child(2) { border-right: 0; }
-  .host-links a:nth-child(-n+2) { border-bottom: 1px solid #e1e4e9; }
 }
 
 @media (max-width: 700px) {
@@ -201,14 +202,16 @@ body { background: #fdfeff; }
   .VPHero .image { display: none; }
   .VPHero .text { font-size: 42px; }
   .VPHome section:not(.boundary-section):not(.final-cta) { padding-inline: 18px; }
-  .home-proof { grid-template-columns: 1fr; padding-bottom: 62px; }
-  .home-proof p, .home-proof p:last-child { border: 1px solid #e1e4e9; border-bottom: 0; }
-  .home-proof p:last-child { border-bottom: 1px solid #e1e4e9; }
+  .home-use-cases { grid-template-columns: 1fr; padding-bottom: 62px; }
+  .home-use-cases a, .home-use-cases a:last-child { border: 1px solid #e1e4e9; border-bottom: 0; }
+  .home-use-cases a:last-child { border-bottom: 1px solid #e1e4e9; }
   .home-demo { padding-bottom: 68px; }
-  .download-section, .mcp-section, .faq-section { padding-block: 66px !important; }
+  .download-section, .sdk-section, .client-section, .faq-section { padding-block: 66px !important; }
   .download-grid { grid-template-columns: 1fr; }
   .download-option, .download-option:last-child { min-height: 72px; border-right: 0; border-bottom: 1px solid #c8cdd6; }
   .download-option:last-child { border-bottom: 0; }
+  .sdk-layout { grid-template-columns: 1fr; }
+  .install-command:first-child { border-right: 0; border-bottom: 1px solid #29323e; }
   .boundary-section, .final-cta { padding: 66px 18px !important; }
 }
 
@@ -217,9 +220,6 @@ body { background: #fdfeff; }
   .terminal-event > span:last-child { grid-column: 2; }
   .terminal-receipt { grid-template-columns: 1fr auto; }
   .terminal-receipt code { grid-column: 1 / -1; grid-row: 2; }
-  .host-links { grid-template-columns: 1fr; }
-  .host-links a { border-right: 0; border-bottom: 1px solid #e1e4e9; }
-  .host-links a:last-child { border-bottom: 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -81,6 +81,10 @@ body { background: #fdfeff; }
 .section-heading { max-width: 700px; }
 .section-heading > p:last-child { max-width: 650px; margin-top: 16px; font-size: 17px; line-height: 1.65; }
 
+.release-candidate-note { display: flex; gap: 18px; align-items: baseline; padding-block: 16px 30px; color: #5e6675; font-size: 13px; }
+.release-candidate-note strong { color: #a76400; white-space: nowrap; }
+.release-candidate-note a { color: #1e55e6; }
+
 .home-use-cases { display: grid; grid-template-columns: repeat(3, 1fr); padding-bottom: 80px; }
 .home-use-cases a {
   display: flex;
@@ -202,6 +206,7 @@ body { background: #fdfeff; }
   .VPHero .image { display: none; }
   .VPHero .text { font-size: 42px; }
   .VPHome section:not(.boundary-section):not(.final-cta) { padding-inline: 18px; }
+  .release-candidate-note { display: grid; gap: 6px; }
   .home-use-cases { grid-template-columns: 1fr; padding-bottom: 62px; }
   .home-use-cases a, .home-use-cases a:last-child { border: 1px solid #e1e4e9; border-bottom: 0; }
   .home-use-cases a:last-child { border-bottom: 1px solid #e1e4e9; }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,12 +27,14 @@ python -m pip install ./sdks/python
 npm install ./sdks/typescript
 ```
 
-After publication, install from the registries:
+After publication, install the exact GitHub release packages:
 
 ```bash
-pip install rookhold
-npm install rookhold
+pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl
+npm install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz
 ```
+
+Named PyPI and npm installs are deferred until maintainer registry activation.
 
 These packages are clients. Installing them does not create the guarded Linux
 execution boundary.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,13 +4,14 @@ Choose the Rookhold surface that matches what you are doing.
 
 ## Rookhold app
 
-Use the complete app when you want `rookhold run`, a local trusted-code service,
-the persistent server, setup commands, the remote client, MCP, and the verifier.
+After v0.8.0 publishes, use the complete app when you want `rookhold run`, a
+local trusted-code service, the persistent server, setup commands, remote
+client, MCP, and the verifier.
 
 | Computer | App bundle |
 |---|---|
 | Windows, 64-bit | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip) |
-| Mac with Apple silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
+| Mac with Apple Silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
 | Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz) |
 
 The exact release, checksums, SBOM, provenance, SDK artifacts, and standalone
@@ -18,7 +19,15 @@ clients are on the [v0.8.0 release](https://github.com/sambai-dev/rookhold/relea
 
 ## SDK
 
-Use an SDK when an application submits jobs to a Rookhold endpoint.
+Use an SDK when an application submits jobs to a Rookhold endpoint. Before
+v0.8.0 publishes, install the candidate from the checkout:
+
+```bash
+python -m pip install ./sdks/python
+npm install ./sdks/typescript
+```
+
+After publication, install from the registries:
 
 ```bash
 pip install rookhold
@@ -30,13 +39,14 @@ execution boundary.
 
 ## Standalone client
 
-Use `rookhold-cli` when a person or MCP host already has a Rookhold endpoint and
-does not need the service or local-run workflow.
+After v0.8.0 publishes, use the standalone `rookhold-cli` download when a person
+or MCP host already has a Rookhold endpoint and does not need the service or
+local-run workflow.
 
 | Computer | Client |
 |---|---|
 | Windows, 64-bit | [Download the Windows client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-pc-windows-msvc.exe) |
-| Mac with Apple silicon | [Download the Mac client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin) |
+| Mac with Apple Silicon | [Download the Mac client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin) |
 | Linux x86_64 | [Download the Linux client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu) |
 
 Mac and Linux users must mark direct executable downloads with `chmod +x`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,28 +1,49 @@
 # Installation
 
-The `rookhold` registry packages are prepared for v0.8.0 but are not public
-yet. Until the release is tagged, install from a checkout.
+Choose the Rookhold surface that matches what you are doing.
 
-## Python from a checkout
+## Rookhold app
+
+Use the complete app when you want `rookhold run`, a local trusted-code service,
+the persistent server, setup commands, the remote client, MCP, and the verifier.
+
+| Computer | App bundle |
+|---|---|
+| Windows, 64-bit | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip) |
+| Mac with Apple silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
+| Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz) |
+
+The exact release, checksums, SBOM, provenance, SDK artifacts, and standalone
+clients are on the [v0.8.0 release](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0).
+
+## SDK
+
+Use an SDK when an application submits jobs to a Rookhold endpoint.
 
 ```bash
-python -m pip install ./sdks/python
+pip install rookhold
+npm install rookhold
 ```
 
-## TypeScript from a checkout
+These packages are clients. Installing them does not create the guarded Linux
+execution boundary.
 
-```bash
-cd sdks/typescript
-npm ci
-npm pack
-```
+## Standalone client
 
-After v0.8.0 publishes, use `pip install rookhold` or `npm install rookhold`.
+Use `rookhold-cli` when a person or MCP host already has a Rookhold endpoint and
+does not need the service or local-run workflow.
 
-## Command and service
+| Computer | Client |
+|---|---|
+| Windows, 64-bit | [Download the Windows client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-pc-windows-msvc.exe) |
+| Mac with Apple silicon | [Download the Mac client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin) |
+| Linux x86_64 | [Download the Linux client](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu) |
 
-The unified v0.8 archive is not public yet. The current stable archive is the
-[v0.7.1 release](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1).
-The archive contains `rookhold`, the MCP adapter, and the offline verifier.
-Verify `SHA256SUMS` and GitHub provenance before allowing an unsigned community
-binary to run.
+Mac and Linux users must mark direct executable downloads with `chmod +x`.
+Keep credentials in the environment or a managed secret mechanism.
+
+## Verify a release
+
+Before running an unsigned community binary, verify its `SHA256SUMS` entry and
+GitHub provenance. The [deployment guide](../deployment.md) contains exact
+Linux, macOS, and Windows verification commands.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,12 +1,21 @@
 # Quickstart
 
-Download the complete Rookhold app for your computer:
+After v0.8.0 publishes, download the complete Rookhold app for your computer:
 
 | Computer | App bundle |
 |---|---|
 | Windows, 64-bit | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip) |
-| Mac with Apple silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
+| Mac with Apple Silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
 | Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz) |
+
+Before publication, run the same candidate from a checkout:
+
+```bash
+git clone https://github.com/sambai-dev/rookhold.git
+cd rookhold
+cargo build --locked -p coop-server --bin rookhold
+target/debug/rookhold run python 'print(6 * 7)'
+```
 
 Extract it, then run one job. On Windows:
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,20 +1,27 @@
 # Quickstart
 
-The one-command flow is available on `main` and will ship in v0.8.0. Build the
-current checkout, then run:
+Download the complete Rookhold app for your computer:
 
-```bash
-cargo build --locked -p coop-server --bin rookhold
-cp target/debug/rookhold ./rookhold
-rookhold run python 'print(6 * 7)'
+| Computer | App bundle |
+|---|---|
+| Windows, 64-bit | [Download for Windows](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip) |
+| Mac with Apple silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
+| Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz) |
+
+Extract it, then run one job. On Windows:
+
+```powershell
+.\rookhold.exe run python 'print(6 * 7)'
 ```
 
-The current published release is
-[v0.7.1](https://github.com/sambai-dev/rookhold/releases/tag/v0.7.1) and still
-uses the explicit service-plus-client flow.
+On macOS or Linux:
 
-Without configured service variables, the command manages a temporary
-loopback-only development service and prints an unavoidable warning:
+```bash
+chmod +x rookhold rookhold-cli rookhold-mcp rookhold-verify
+./rookhold run python 'print(6 * 7)'
+```
+
+The zero-configuration path starts and stops a temporary loopback service:
 
 ```text
 42
@@ -23,15 +30,28 @@ status       succeeded
 network      host
 isolation    none
 receipt      saved to .rookhold/runs/…/receipt.json
+
+WARNING: isolation is none; this run did not contain untrusted code.
 ```
 
-That path is for trusted code only. For an existing service:
+::: warning Trusted code only
+This local mode is convenient, not contained. It has host networking and the
+service account's authority. Use it only for code you trust.
+:::
+
+For untrusted code, connect the same app to a guarded Linux service and require
+its observed isolation class:
 
 ```bash
-export ROOKHOLD_BASE_URL=https://rookhold.example.internal
+export ROOKHOLD_BASE_URL=https://executor.example
 export ROOKHOLD_API_KEY=replace-with-a-scoped-key
-rookhold check
-rookhold run python 'print(6 * 7)'
+rookhold run python 'print(6 * 7)' \
+  --minimum-isolation gvisor-application-kernel
 ```
 
-Next: [install an SDK](installation.md) or [deploy the secure Linux boundary](first-secure-deployment.md).
+That connected run should report `network: disabled` and
+`isolation: gvisor-application-kernel`. Rookhold fails admission if the service
+cannot satisfy the requested class.
+
+Next: [install an SDK](installation.md#sdk) or
+[deploy the secure Linux boundary](first-secure-deployment.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,6 +17,8 @@ cargo build --locked -p coop-server --bin rookhold
 target/debug/rookhold run python 'print(6 * 7)'
 ```
 
+## After v0.8.0 publishes
+
 Extract it, then run one job. On Windows:
 
 ```powershell
@@ -60,7 +62,10 @@ rookhold run python 'print(6 * 7)' \
 
 That connected run should report `network: disabled` and
 `isolation: gvisor-application-kernel`. Rookhold fails admission if the service
-cannot satisfy the requested class.
+cannot satisfy the requested class. The unified CLI explicitly sends
+`limits.allow_network: false` with every submission, so the guarded run requires
+both the network policy and the gVisor boundary instead of inferring either from
+display text.
 
 Next: [install an SDK](installation.md#sdk) or
 [deploy the secure Linux boundary](first-secure-deployment.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,11 @@ hero:
       link: /use/mcp
 ---
 
+<section class="release-candidate-note" aria-label="v0.8.0 publication status">
+  <strong>v0.8.0 release candidate</strong>
+  <span>Downloads and registry commands activate after the release workflow publishes. Until then, <a href="https://github.com/sambai-dev/rookhold#build-from-source">build from main</a>.</span>
+</section>
+
 <section class="home-use-cases" aria-label="Common Rookhold use cases">
   <a href="https://github.com/sambai-dev/rookhold/tree/main/examples/llm-tool-call"><strong>Generated functions</strong><span>Run model-produced source outside the agent process.</span></a>
   <a href="https://github.com/sambai-dev/rookhold/tree/main/examples/json-transform"><strong>JSON transforms</strong><span>Apply user-defined code to structured input.</span></a>
@@ -47,11 +52,11 @@ hero:
 <section id="try" class="download-section" aria-labelledby="try-heading">
   <div class="section-heading">
     <h2 id="try-heading">Try the Rookhold app.</h2>
-    <p>The complete bundle contains the unified app, local service, remote client, MCP adapter, verifier, and setup templates.</p>
+    <p>After v0.8.0 publishes, the complete bundle contains the unified app, local service, remote client, MCP adapter, verifier, and setup templates.</p>
   </div>
   <div class="download-grid">
     <a class="download-option" aria-label="Download the Rookhold app for 64-bit Windows" href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip"><strong>Windows</strong></a>
-    <a class="download-option" aria-label="Download the Rookhold app for Apple silicon Mac" href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz"><strong>Mac</strong></a>
+    <a class="download-option" aria-label="Download the Rookhold app for Apple Silicon Mac" href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz"><strong>Mac</strong></a>
     <a class="download-option" aria-label="Download the Rookhold app for Linux x86_64" href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz"><strong>Linux</strong></a>
   </div>
   <p class="download-compatibility">Windows and Linux: 64-bit Intel or AMD. Mac: Apple silicon. Mac and Linux users run <code>chmod +x</code> once after extracting.</p>
@@ -60,7 +65,7 @@ hero:
 <section id="sdk" class="sdk-section" aria-labelledby="sdk-heading">
   <div class="section-heading">
     <h2 id="sdk-heading">Add Rookhold to an application.</h2>
-    <p>The SDKs submit jobs to a Rookhold endpoint. They do not create the guarded Linux execution boundary by themselves.</p>
+    <p>After v0.8.0 publishes, install the SDKs from the registries. They submit jobs to an endpoint and do not create the guarded Linux boundary by themselves.</p>
   </div>
   <div class="sdk-layout">
     <div class="install-command"><span>Python</span><code>pip install rookhold</code><a href="./use/python">Python guide →</a></div>
@@ -71,7 +76,7 @@ hero:
 <section class="client-section" aria-labelledby="client-heading">
   <div class="section-heading">
     <h2 id="client-heading">Already have a Rookhold server?</h2>
-    <p>The standalone Rookhold client is the smaller human and MCP interface. It does not include the service or local-run workflow.</p>
+    <p>After v0.8.0 publishes, the standalone client is the smaller human and MCP interface. It does not include the service or local-run workflow.</p>
     <div class="home-demo-actions">
       <a class="home-text-link" href="./use/cli">Client guide <span aria-hidden="true">→</span></a>
       <a class="home-text-link" href="./use/mcp">MCP setup <span aria-hidden="true">→</span></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,8 +68,8 @@ hero:
     <p>After v0.8.0 publishes, install the SDKs from the registries. They submit jobs to an endpoint and do not create the guarded Linux boundary by themselves.</p>
   </div>
   <div class="sdk-layout">
-    <div class="install-command"><span>Python</span><code>pip install …/rookhold-0.8.0-py3-none-any.whl</code><a href="./use/python">Python guide →</a></div>
-    <div class="install-command"><span>TypeScript</span><code>npm install …/rookhold-0.8.0.tgz</code><a href="./use/typescript">TypeScript guide →</a></div>
+    <div class="install-command"><span>Python</span><code>pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl</code><a href="./use/python">Python guide →</a></div>
+    <div class="install-command"><span>TypeScript</span><code>npm install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz</code><a href="./use/typescript">TypeScript guide →</a></div>
     <p>Named PyPI and npm installs are deferred while maintainer registry accounts are activated; v0.8.0 ships the exact packages as verified release assets.</p>
   </div>
 </section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,8 +68,9 @@ hero:
     <p>After v0.8.0 publishes, install the SDKs from the registries. They submit jobs to an endpoint and do not create the guarded Linux boundary by themselves.</p>
   </div>
   <div class="sdk-layout">
-    <div class="install-command"><span>Python</span><code>pip install rookhold</code><a href="./use/python">Python guide →</a></div>
-    <div class="install-command"><span>TypeScript</span><code>npm install rookhold</code><a href="./use/typescript">TypeScript guide →</a></div>
+    <div class="install-command"><span>Python</span><code>pip install …/rookhold-0.8.0-py3-none-any.whl</code><a href="./use/python">Python guide →</a></div>
+    <div class="install-command"><span>TypeScript</span><code>npm install …/rookhold-0.8.0.tgz</code><a href="./use/typescript">TypeScript guide →</a></div>
+    <p>Named PyPI and npm installs are deferred while maintainer registry accounts are activated; v0.8.0 ships the exact packages as verified release assets.</p>
   </div>
 </section>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,120 +1,109 @@
 ---
 layout: home
 title: Rookhold
-titleTemplate: Controlled code execution for AI agents
-description: Download the Rookhold CLI and connect Claude Code, OpenCode, Hermes, or another MCP host to a controlled execution service.
+titleTemplate: Short-lived code with hard limits and receipts
+description: Execute short Python, Node, and Bash jobs submitted by an application, agent, or user with hard limits and a verifiable receipt.
 
 hero:
-  text: Run agent code behind a boundary you control.
-  tagline: One downloadable CLI connects your app or agent to short Python, Node, and Bash jobs with hard limits, bounded live output, and a verifiable receipt.
+  text: Run short-lived code with hard limits—and keep a receipt.
+  tagline: Execute Python, Node, and Bash submitted by an application, agent, or user without turning your machine into the execution environment.
   image:
     src: /rook.svg
     alt: Rookhold black-square emblem
   actions:
     - theme: brand
-      text: Download the CLI
-      link: '#download'
+      text: Try locally
+      link: '#try'
+    - theme: alt
+      text: Install an SDK
+      link: '#sdk'
     - theme: alt
       text: Connect an MCP host
       link: /use/mcp
 ---
 
-<section class="home-proof" aria-label="Release facts">
-  <p><strong>Current stable</strong><span>v0.7.1</span></p>
-  <p><strong>Agent interface</strong><span>MCP over stdio</span></p>
-  <p><strong>Production boundary</strong><span>gVisor on Linux x86_64</span></p>
+<section class="home-use-cases" aria-label="Common Rookhold use cases">
+  <a href="https://github.com/sambai-dev/rookhold/tree/main/examples/llm-tool-call"><strong>Generated functions</strong><span>Run model-produced source outside the agent process.</span></a>
+  <a href="https://github.com/sambai-dev/rookhold/tree/main/examples/json-transform"><strong>JSON transforms</strong><span>Apply user-defined code to structured input.</span></a>
+  <a href="https://github.com/sambai-dev/rookhold/tree/main/examples/evaluator"><strong>Code grading</strong><span>Bound hidden-test evaluation and keep the record.</span></a>
 </section>
 
 <section class="home-demo" aria-labelledby="demo-heading">
   <div class="home-demo-copy">
-    <h2 id="demo-heading">One file for you and your agent.</h2>
-    <p>The normal command opens Rookhold's operator CLI. The <code>mcp-server</code> argument turns that same executable into a concurrent stdio MCP server with four narrow execution tools.</p>
-    <div class="home-demo-actions">
-      <a class="home-text-link" href="./use/cli">Open the CLI guide <span aria-hidden="true">→</span></a>
-      <a class="home-text-link" href="./use/mcp">Open the MCP guide <span aria-hidden="true">→</span></a>
-    </div>
+    <h2 id="demo-heading">One command to a real result.</h2>
+    <p>With no endpoint configured, the Rookhold app starts a temporary loopback service, runs trusted code, saves the receipt, and removes the service state. It reports the weak local posture plainly.</p>
+    <a class="home-text-link" href="./getting-started/quickstart">Open the two-minute quickstart <span aria-hidden="true">→</span></a>
   </div>
-  <div class="terminal-stage" role="img" aria-label="Rookhold CLI showing a successful bounded Python job and saved receipt">
-    <div class="terminal-head"><span>rookhold-cli</span><span>connected · gvisor</span></div>
-    <div class="terminal-line"><span class="prompt">›</span><span>/run python "print(6 * 7)"</span></div>
-    <div class="terminal-event"><span>01</span><strong>policy accepted</strong><span>network disabled · 2s wall</span></div>
-    <div class="terminal-event"><span>02</span><strong>job completed</strong><span>42</span></div>
-    <div class="terminal-receipt"><span>receipt</span><code>.rookhold/runs/…/receipt.json</code><b>succeeded</b></div>
+  <div class="terminal-stage" role="img" aria-label="Local trusted-code run reporting host networking and no isolation">
+    <div class="terminal-head"><span>rookhold app</span><span class="local-caution">local · trusted code only</span></div>
+    <div class="terminal-line"><span class="prompt">›</span><span>rookhold run python "print(6 * 7)"</span></div>
+    <div class="terminal-event"><span>01</span><strong>job completed</strong><span>42</span></div>
+    <div class="terminal-event"><span>02</span><strong>network</strong><span>host</span></div>
+    <div class="terminal-event"><span>03</span><strong>isolation</strong><span>none</span></div>
+    <div class="terminal-receipt"><span>receipt</span><code>.rookhold/runs/…/receipt.json</code><b>saved</b></div>
   </div>
 </section>
 
-<section id="download" class="download-section" aria-labelledby="download-heading">
+<section id="try" class="download-section" aria-labelledby="try-heading">
   <div class="section-heading">
-    <h2 id="download-heading">Download Rookhold.</h2>
-    <p>Choose your computer. Each option is one self-contained CLI file.</p>
+    <h2 id="try-heading">Try the Rookhold app.</h2>
+    <p>The complete bundle contains the unified app, local service, remote client, MCP adapter, verifier, and setup templates.</p>
   </div>
   <div class="download-grid">
-    <a class="download-option" aria-label="Download Rookhold for 64-bit Windows" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-pc-windows-msvc.exe">
-      <strong>Windows</strong>
-    </a>
-    <a class="download-option" aria-label="Download Rookhold for Apple silicon Mac" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-aarch64-apple-darwin">
-      <strong>Mac</strong>
-    </a>
-    <a class="download-option" aria-label="Download Rookhold for 64-bit Intel or AMD Linux" href="https://github.com/sambai-dev/rookhold/releases/download/v0.7.1/rookhold-cli-x86_64-unknown-linux-gnu">
-      <strong>Linux</strong>
-    </a>
+    <a class="download-option" aria-label="Download the Rookhold app for 64-bit Windows" href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip"><strong>Windows</strong></a>
+    <a class="download-option" aria-label="Download the Rookhold app for Apple silicon Mac" href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz"><strong>Mac</strong></a>
+    <a class="download-option" aria-label="Download the Rookhold app for Linux x86_64" href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz"><strong>Linux</strong></a>
   </div>
-  <p class="download-compatibility">Windows and Linux: 64-bit Intel or AMD. Mac: Apple silicon. Mac and Linux users run <code>chmod +x</code> once after downloading.</p>
+  <p class="download-compatibility">Windows and Linux: 64-bit Intel or AMD. Mac: Apple silicon. Mac and Linux users run <code>chmod +x</code> once after extracting.</p>
 </section>
 
-<section class="mcp-section" aria-labelledby="mcp-heading">
+<section id="sdk" class="sdk-section" aria-labelledby="sdk-heading">
   <div class="section-heading">
-    <h2 id="mcp-heading">Connect any local MCP host.</h2>
-    <p>Rookhold keeps the endpoint, credential, allowed languages, and minimum isolation outside the model's tool arguments.</p>
+    <h2 id="sdk-heading">Add Rookhold to an application.</h2>
+    <p>The SDKs submit jobs to a Rookhold endpoint. They do not create the guarded Linux execution boundary by themselves.</p>
   </div>
-  <div class="mcp-layout">
-    <div class="mcp-code" aria-label="Generic MCP configuration example">
-      <div class="mcp-code-head"><span>mcp.json</span><span>stdio</span></div>
-      <pre><code>{
-  "mcpServers": {
-    "rookhold": {
-      "command": "rookhold-cli",
-      "args": ["mcp-server"]
-    }
-  }
-}</code></pre>
+  <div class="sdk-layout">
+    <div class="install-command"><span>Python</span><code>pip install rookhold</code><a href="./use/python">Python guide →</a></div>
+    <div class="install-command"><span>TypeScript</span><code>npm install rookhold</code><a href="./use/typescript">TypeScript guide →</a></div>
+  </div>
+</section>
+
+<section class="client-section" aria-labelledby="client-heading">
+  <div class="section-heading">
+    <h2 id="client-heading">Already have a Rookhold server?</h2>
+    <p>The standalone Rookhold client is the smaller human and MCP interface. It does not include the service or local-run workflow.</p>
+    <div class="home-demo-actions">
+      <a class="home-text-link" href="./use/cli">Client guide <span aria-hidden="true">→</span></a>
+      <a class="home-text-link" href="./use/mcp">MCP setup <span aria-hidden="true">→</span></a>
     </div>
-    <ol class="mcp-steps">
-      <li><span>01</span><div><strong>Download one file</strong><p>Put <code>rookhold-cli</code> on PATH or use its absolute path.</p></div></li>
-      <li><span>02</span><div><strong>Set operator policy</strong><p>Export the endpoint, scoped key, language allowlist, and required isolation class.</p></div></li>
-      <li><span>03</span><div><strong>Register and check</strong><p>Launch <code>mcp-server</code>, then confirm the four live Rookhold tools in your host.</p></div></li>
-    </ol>
   </div>
-  <div class="host-links" aria-label="Supported host guides">
-    <a href="https://github.com/sambai-dev/rookhold/blob/main/integrations/claude-code/mcp.json">Claude Code</a>
-    <a href="https://github.com/sambai-dev/rookhold/blob/main/integrations/opencode/opencode.snippet.json">OpenCode</a>
-    <a href="https://github.com/sambai-dev/rookhold/blob/main/integrations/hermes/config.snippet.yaml">Hermes</a>
-    <a href="./use/mcp">Generic MCP</a>
+  <div class="client-links" aria-label="Standalone client downloads">
+    <a href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-pc-windows-msvc.exe">Windows client</a>
+    <a href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin">Mac client</a>
+    <a href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu">Linux client</a>
   </div>
 </section>
 
 <section class="boundary-section" aria-labelledby="boundary-heading">
-  <div>
-    <h2 id="boundary-heading">The website is hosted. The executor is yours.</h2>
-  </div>
+  <div><h2 id="boundary-heading">The local demo is not the security boundary.</h2></div>
   <div class="boundary-copy">
-    <p>Vercel serves these public docs. Download links point directly to immutable GitHub Releases assets. Vercel does not run Rookhold's privileged execution backend.</p>
     <p>For untrusted code, operate Rookhold on a dedicated Linux x86_64 host with the pinned gVisor provider. Local development on Windows, macOS, or an unisolated Linux setup reports <code>isolation: none</code>.</p>
+    <p>Requested policy, observed controls, and portable proof stay separate. A run fails admission when the service cannot satisfy its required isolation class.</p>
     <a class="home-text-link" href="./getting-started/first-secure-deployment">Build the secure boundary <span aria-hidden="true">→</span></a>
   </div>
 </section>
 
 <section class="faq-section" aria-labelledby="faq-heading">
-  <div class="section-heading"><h2 id="faq-heading">The short answers.</h2></div>
+  <div class="section-heading"><h2 id="faq-heading">Choose the right surface.</h2></div>
   <div class="faq-list">
-    <details><summary>Does the CLI include the sandbox service?</summary><p>The full release archive includes the service and verifier. The one-file CLI is the consumer interface and connects to a separately operated Rookhold endpoint.</p></details>
-    <details><summary>Does MCP replace Claude Code or OpenCode?</summary><p>No. Your existing host owns the conversation and model. Rookhold adds four execution tools with policy and evidence.</p></details>
-    <details><summary>Does adding Rookhold disable the host's shell?</summary><p>No. Remove or deny alternate shell and code-execution tools when the model must cross only the Rookhold boundary.</p></details>
-    <details><summary>Can I safely run untrusted code on my laptop?</summary><p>No. The local demo is explicitly unisolated. Use the dedicated Linux gVisor deployment for the production boundary.</p></details>
+    <details><summary>Which download should I use first?</summary><p>Use the complete Rookhold app bundle for your operating system. It includes the zero-configuration local path and the server.</p></details>
+    <details><summary>When should I use the standalone client?</summary><p>Use it only when you already have a Rookhold endpoint and want the smaller operator or MCP interface.</p></details>
+    <details><summary>Do the SDKs include the sandbox service?</summary><p>No. They submit to an endpoint. The secure boundary is a separately operated Linux service.</p></details>
+    <details><summary>Can I safely run untrusted code on my laptop?</summary><p>No. The local mode is explicitly unisolated. Use the dedicated Linux gVisor deployment for mutually untrusted code.</p></details>
   </div>
 </section>
 
-<section class="final-cta" aria-label="Download Rookhold">
-  <h2>Give your agent a controlled place to run code.</h2>
-  <a href="#download">Download Rookhold v0.7.1 <span aria-hidden="true">↓</span></a>
+<section class="final-cta" aria-label="Try Rookhold locally">
+  <h2>Run one trusted local job, then decide where the boundary belongs.</h2>
+  <a href="#try">Try Rookhold locally <span aria-hidden="true">↓</span></a>
 </section>

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# Rookhold Sandbox documentation
+# Rookhold documentation
 
 Rookhold runs short Python, Node, and Bash jobs with hard limits, live output,
 and receipts. It is not a persistent development workspace or remote computer.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -59,7 +59,7 @@ For a matching, finalized tag the workflow:
 4. safely extracts and inventories those nine payloads into a fresh staging tree and produces one combined, artifact-scoped SPDX JSON SBOM;
 5. binds the SPDX predicate to all nine payload digests, writes `SHA256SUMS` for the other ten public assets, and records SLSA provenance for the exact eleven-asset set through OIDC;
 6. uploads only those eleven names to a draft release, reconciles every remote name, size, and SHA-256 digest against the local files, and preserves that exact staged set as an internal workflow artifact;
-7. publishes the Python and TypeScript packages through their GitHub OIDC trusted publishers;
+7. reconciles any prior partial registry attempt by exact digest, publishes only missing Python or TypeScript packages through their GitHub OIDC trusted publishers, and fails closed if an existing public artifact differs;
 8. clean-installs and imports the exact versions from public PyPI and npm; and
 9. re-verifies the unchanged remote draft against the preserved eleven-asset set, then publishes the GitHub Release only after both registry smoke tests succeed.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,8 +13,8 @@ Configure these controls in GitHub before setting the repository variable `ROOKH
 5. Enable GitHub immutable releases so a published tag or asset cannot be silently replaced. The workflow's draft-staging step remains editable until publication; immutability applies to the published release.
 6. Review Actions access so only required, SHA-pinned actions are allowed. Keep the default workflow token read-only; grant contents, attestation, and OIDC permissions only to the narrowly scoped release-staging, registry-publication, and final-publication jobs that require them.
 7. Package registry publication may follow the immutable GitHub release. On PyPI, configure a pending trusted publisher for project `rookhold`, owner
-   `sambai-dev`, repository `rookhold`, workflow `release.yml`, and environment
-   `release`, using workflow `publish-packages.yml`. A pending publisher does not reserve the name until the first
+   `sambai-dev`, repository `rookhold`, workflow `publish-packages.yml`, and environment
+   `release`. `release.yml` remains the artifact-attestation workflow. A pending publisher does not reserve the name until the first
    publish, so complete the release promptly after this check.
 8. npm does not offer PyPI-style pending publishers. Before the final tag,
    bootstrap the unclaimed `rookhold` package through the maintainer's
@@ -22,7 +22,7 @@ Configure these controls in GitHub before setting the repository variable `ROOKH
    GitHub Actions trusted publisher for owner `sambai-dev`, repository
    `rookhold`, workflow `publish-packages.yml`, environment `release`, and `npm publish`.
    Confirm the package's repository URL resolves exactly to this repository.
-   The final `0.8.0` publication must still come from the tagged OIDC workflow.
+   The final `0.8.0` publication must come from the protected OIDC follow-up workflow and reuse the tagged release asset.
 
 Registry activation does not block the binary release. Until the protected
 follow-up workflow publishes the immutable SDK assets, documentation must use

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,24 +12,22 @@ Configure these controls in GitHub before setting the repository variable `ROOKH
 4. Enable private vulnerability reporting and verify the contact in [SECURITY.md](https://github.com/sambai-dev/rookhold/blob/main/SECURITY.md).
 5. Enable GitHub immutable releases so a published tag or asset cannot be silently replaced. The workflow's draft-staging step remains editable until publication; immutability applies to the published release.
 6. Review Actions access so only required, SHA-pinned actions are allowed. Keep the default workflow token read-only; grant contents, attestation, and OIDC permissions only to the narrowly scoped release-staging, registry-publication, and final-publication jobs that require them.
-7. On PyPI, configure a pending trusted publisher for project `rookhold`, owner
+7. Package registry publication may follow the immutable GitHub release. On PyPI, configure a pending trusted publisher for project `rookhold`, owner
    `sambai-dev`, repository `rookhold`, workflow `release.yml`, and environment
-   `release`. A pending publisher does not reserve the name until the first
+   `release`, using workflow `publish-packages.yml`. A pending publisher does not reserve the name until the first
    publish, so complete the release promptly after this check.
 8. npm does not offer PyPI-style pending publishers. Before the final tag,
    bootstrap the unclaimed `rookhold` package through the maintainer's
    2FA-protected npm account (a prerelease is preferred), then configure its
    GitHub Actions trusted publisher for owner `sambai-dev`, repository
-   `rookhold`, workflow `release.yml`, environment `release`, and `npm publish`.
+   `rookhold`, workflow `publish-packages.yml`, environment `release`, and `npm publish`.
    Confirm the package's repository URL resolves exactly to this repository.
    The final `0.8.0` publication must still come from the tagged OIDC workflow.
 
-The repository variables are acknowledgements, not proof. Recheck the settings
-after ownership, plan, or organization-policy changes. Set
-`ROOKHOLD_RELEASE_GOVERNANCE`, `ROOKHOLD_PYPI_TRUSTED_PUBLISHER`, and
-`ROOKHOLD_NPM_TRUSTED_PUBLISHER` to `enabled` only after the corresponding
-checks. An unset variable stops the tag workflow before any build or draft
-release is created.
+Registry activation does not block the binary release. Until the protected
+follow-up workflow publishes the immutable SDK assets, documentation must use
+their exact GitHub release URLs and state that named registry installs are
+deferred.
 
 ## Per-release checklist
 
@@ -59,9 +57,8 @@ For a matching, finalized tag the workflow:
 4. safely extracts and inventories those nine payloads into a fresh staging tree and produces one combined, artifact-scoped SPDX JSON SBOM;
 5. binds the SPDX predicate to all nine payload digests, writes `SHA256SUMS` for the other ten public assets, and records SLSA provenance for the exact eleven-asset set through OIDC;
 6. uploads only those eleven names to a draft release, reconciles every remote name, size, and SHA-256 digest against the local files, and preserves that exact staged set as an internal workflow artifact;
-7. reconciles any prior partial registry attempt by exact digest, publishes only missing Python or TypeScript packages through their GitHub OIDC trusted publishers, and fails closed if an existing public artifact differs;
-8. clean-installs and imports the exact versions from public PyPI and npm; and
-9. re-verifies the unchanged remote draft against the preserved eleven-asset set, then publishes the GitHub Release only after both registry smoke tests succeed.
+7. clean-installs and imports the exact wheel and npm tarball from the gated workflow artifacts; and
+8. re-verifies the unchanged remote draft against the preserved eleven-asset set, then publishes the GitHub Release.
 
 The public contract is exactly eleven assets: three complete platform archives, three direct single-file CLI downloads, the Python wheel and source distribution, the npm tarball, the combined SPDX JSON document, and `SHA256SUMS`. Every platform archive contains the native service and verifier plus standalone `rookhold-cli` and `rookhold-mcp` apps that do not require Python. The checksum manifest covers the other ten assets and cannot include its own digest; its release attestation and constrained workflow provenance authenticate the manifest itself. GitHub-generated source archives are outside this asset set.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -11,7 +11,7 @@ Configure these controls in GitHub before setting the repository variable `ROOKH
 3. Create a `release` environment restricted to `v*` tags and require explicit reviewer approval. Use an independent trusted reviewer and prevent self-review whenever a second trusted maintainer is available. A solo-maintainer repository may temporarily designate its owner, must record the explicit approval, and should switch to independent approval as soon as another maintainer is established.
 4. Enable private vulnerability reporting and verify the contact in [SECURITY.md](https://github.com/sambai-dev/rookhold/blob/main/SECURITY.md).
 5. Enable GitHub immutable releases so a published tag or asset cannot be silently replaced. The workflow's draft-staging step remains editable until publication; immutability applies to the published release.
-6. Review Actions access so only required, SHA-pinned actions are allowed. Keep the default workflow token read-only; only the final publish job receives contents, attestation, and OIDC write permissions.
+6. Review Actions access so only required, SHA-pinned actions are allowed. Keep the default workflow token read-only; grant contents, attestation, and OIDC permissions only to the narrowly scoped release-staging, registry-publication, and final-publication jobs that require them.
 7. On PyPI, configure a pending trusted publisher for project `rookhold`, owner
    `sambai-dev`, repository `rookhold`, workflow `release.yml`, and environment
    `release`. A pending publisher does not reserve the name until the first
@@ -45,7 +45,7 @@ release is created.
    `rookhold-verify` vectors, and real pinned-runsc lifecycle without skips. Confirm
    the archive and image contain the matching `rookhold-verify`/init binaries.
 10. Create and push the protected `vVERSION` tag from the reviewed commit. The tag push starts the release workflow; do not move or reuse the tag.
-11. When the publish job reaches the protected `release` environment, obtain its required approval only after reviewing the completed gates and intended eleven-asset set.
+11. When the protected release jobs reach the `release` environment, obtain the required approval only after reviewing the completed gates, intended eleven-asset set, and registry-publisher configuration.
 
 No release command is run by this documentation. Do not reuse or move a published tag to correct a mistake; increment the version and publish a superseding release. The workflow verifies that the remote tag exists and that the checkout matches the event commit; it does **not** cryptographically verify a signed Git tag. Tag trust currently comes from protected refs, release-environment approval, immutable releases, and workflow OIDC attestations.
 
@@ -58,8 +58,10 @@ For a matching, finalized tag the workflow:
 3. downloads only four exactly named workflow artifacts, then requires exactly three platform archives and three SDK packages;
 4. safely extracts and inventories those nine payloads into a fresh staging tree and produces one combined, artifact-scoped SPDX JSON SBOM;
 5. binds the SPDX predicate to all nine payload digests, writes `SHA256SUMS` for the other ten public assets, and records SLSA provenance for the exact eleven-asset set through OIDC;
-6. uploads only those eight names to a draft release and reconciles every remote name, size, and SHA-256 digest against the local files; and
-7. publishes that draft only after every upload, attestation, and readback succeeds and the protected `release` environment approves the job.
+6. uploads only those eleven names to a draft release, reconciles every remote name, size, and SHA-256 digest against the local files, and preserves that exact staged set as an internal workflow artifact;
+7. publishes the Python and TypeScript packages through their GitHub OIDC trusted publishers;
+8. clean-installs and imports the exact versions from public PyPI and npm; and
+9. re-verifies the unchanged remote draft against the preserved eleven-asset set, then publishes the GitHub Release only after both registry smoke tests succeed.
 
 The public contract is exactly eleven assets: three complete platform archives, three direct single-file CLI downloads, the Python wheel and source distribution, the npm tarball, the combined SPDX JSON document, and `SHA256SUMS`. Every platform archive contains the native service and verifier plus standalone `rookhold-cli` and `rookhold-mcp` apps that do not require Python. The checksum manifest covers the other ten assets and cannot include its own digest; its release attestation and constrained workflow provenance authenticate the manifest itself. GitHub-generated source archives are outside this asset set.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,8 +12,24 @@ Configure these controls in GitHub before setting the repository variable `ROOKH
 4. Enable private vulnerability reporting and verify the contact in [SECURITY.md](https://github.com/sambai-dev/rookhold/blob/main/SECURITY.md).
 5. Enable GitHub immutable releases so a published tag or asset cannot be silently replaced. The workflow's draft-staging step remains editable until publication; immutability applies to the published release.
 6. Review Actions access so only required, SHA-pinned actions are allowed. Keep the default workflow token read-only; only the final publish job receives contents, attestation, and OIDC write permissions.
+7. On PyPI, configure a pending trusted publisher for project `rookhold`, owner
+   `sambai-dev`, repository `rookhold`, workflow `release.yml`, and environment
+   `release`. A pending publisher does not reserve the name until the first
+   publish, so complete the release promptly after this check.
+8. npm does not offer PyPI-style pending publishers. Before the final tag,
+   bootstrap the unclaimed `rookhold` package through the maintainer's
+   2FA-protected npm account (a prerelease is preferred), then configure its
+   GitHub Actions trusted publisher for owner `sambai-dev`, repository
+   `rookhold`, workflow `release.yml`, environment `release`, and `npm publish`.
+   Confirm the package's repository URL resolves exactly to this repository.
+   The final `0.8.0` publication must still come from the tagged OIDC workflow.
 
-The repository variable is an acknowledgement, not proof. Recheck the settings after ownership, plan, or organization-policy changes. An unset variable stops the tag workflow before any build or draft release is created.
+The repository variables are acknowledgements, not proof. Recheck the settings
+after ownership, plan, or organization-policy changes. Set
+`ROOKHOLD_RELEASE_GOVERNANCE`, `ROOKHOLD_PYPI_TRUSTED_PUBLISHER`, and
+`ROOKHOLD_NPM_TRUSTED_PUBLISHER` to `enabled` only after the corresponding
+checks. An unset variable stops the tag workflow before any build or draft
+release is created.
 
 ## Per-release checklist
 

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -2,12 +2,15 @@
 
 Rookhold ships small reference clients under `sdks/`. They intentionally mirror the HTTP API and are suitable for embedding in agent tool loops. The OpenAPI document remains the canonical contract for generated clients.
 
-The v0.8 release workflow is prepared to test SDK source, install the built
-Python wheel and source distribution, pack the TypeScript client, and publish
-the exact gated artifacts to PyPI and npm with GitHub trusted publishing. The
-registry packages are not public until v0.8.0 is tagged and that workflow
-finishes. A final clean-environment job will install `rookhold==0.8.0` and
-`rookhold@0.8.0` from the public registries.
+Install the v0.8 clients from the public registries:
+
+```bash
+pip install rookhold==0.8.0
+npm install rookhold@0.8.0
+```
+
+The release workflow publishes both packages with registry trusted publishing
+and then installs those exact public versions in clean environments.
 
 To install the v0.8.0 release, activate the intended Python virtual environment and download the exact release assets into an otherwise empty working directory. This example verifies both the checksum manifest and GitHub provenance before installation:
 

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -2,7 +2,7 @@
 
 Rookhold ships small reference clients under `sdks/`. They intentionally mirror the HTTP API and are suitable for embedding in agent tool loops. The OpenAPI document remains the canonical contract for generated clients.
 
-Install the v0.8 clients from the public registries:
+After v0.8.0 publishes, install the clients from the public registries:
 
 ```bash
 pip install rookhold==0.8.0
@@ -11,6 +11,17 @@ npm install rookhold@0.8.0
 
 The release workflow publishes both packages with registry trusted publishing
 and then installs those exact public versions in clean environments.
+
+Before publication, install from the checkout with
+`python -m pip install ./sdks/python` or `npm install ./sdks/typescript`.
+
+Exact candidate release files:
+
+- [Python wheel](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl)
+- [Python source distribution](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tar.gz)
+- [npm tarball](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz)
+- [Combined SPDX SBOM](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.spdx.json)
+- [SHA256SUMS](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/SHA256SUMS)
 
 To install the v0.8.0 release, activate the intended Python virtual environment and download the exact release assets into an otherwise empty working directory. This example verifies both the checksum manifest and GitHub provenance before installation:
 

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -2,15 +2,16 @@
 
 Rookhold ships small reference clients under `sdks/`. They intentionally mirror the HTTP API and are suitable for embedding in agent tool loops. The OpenAPI document remains the canonical contract for generated clients.
 
-After v0.8.0 publishes, install the clients from the public registries:
+After v0.8.0 publishes, install the exact release assets:
 
 ```bash
-pip install rookhold==0.8.0
-npm install rookhold@0.8.0
+pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl
+npm install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz
 ```
 
-The release workflow publishes both packages with registry trusted publishing
-and then installs those exact public versions in clean environments.
+Named PyPI and npm installs are deferred while maintainer registry accounts are
+activated. A protected follow-up workflow will publish these same immutable
+v0.8.0 bytes through registry trusted publishing; it does not rebuild them.
 
 Before publication, install from the checkout with
 `python -m pip install ./sdks/python` or `npm install ./sdks/typescript`.

--- a/docs/use/cli.md
+++ b/docs/use/cli.md
@@ -1,7 +1,6 @@
 # CLI
 
-These unified commands are available from `main` and ship with v0.8.0. The
-current stable v0.7.1 archive uses `rookhold-cli` for client commands.
+The v0.8.0 Rookhold app provides the unified local and remote workflow:
 
 ```bash
 rookhold run python 'print(6 * 7)'
@@ -17,3 +16,6 @@ rookhold verify --envelope job.dsse.json --subject job-result.json --public-key 
 set. Otherwise it starts and stops a temporary local development service.
 `rookhold check` tests the service, credential, runtimes, actual isolation, and
 MCP connection with plain pass/warn/fail output.
+
+The separately downloadable `rookhold-cli` is the existing-server client. It
+does not contain the service or the zero-configuration `rookhold run` path.

--- a/docs/use/mcp.md
+++ b/docs/use/mcp.md
@@ -9,8 +9,9 @@ rookhold setup opencode
 ```
 
 The command finds the normal configuration file, shows a diff, creates a
-timestamped backup, writes only after confirmation, keeps the API key in the
-environment, and runs `rookhold check` afterward.
+timestamped backup, prompts before writing by default, keeps the API key in the
+environment, and runs `rookhold check` afterward. Pass `--yes` only when an
+already-reviewed automation should bypass that confirmation prompt.
 
 The standalone existing-server client can serve MCP over stdio. Your host
 launches it with one argument:

--- a/docs/use/mcp.md
+++ b/docs/use/mcp.md
@@ -1,7 +1,19 @@
 # MCP
 
-The same standalone `rookhold-cli` file used by a human can serve MCP over
-stdio. Your host launches it with one argument:
+The Rookhold app can configure maintained hosts safely:
+
+```bash
+rookhold setup claude-code
+rookhold setup hermes
+rookhold setup opencode
+```
+
+The command finds the normal configuration file, shows a diff, creates a
+timestamped backup, writes only after confirmation, keeps the API key in the
+environment, and runs `rookhold check` afterward.
+
+The standalone existing-server client can serve MCP over stdio. Your host
+launches it with one argument:
 
 ```text
 rookhold-cli mcp-server
@@ -27,27 +39,14 @@ export ROOKHOLD_MCP_MINIMUM_ISOLATION=gvisor-application-kernel
 export ROOKHOLD_MCP_ALLOWED_LANGUAGES=python,node
 ```
 
-For the current stable v0.7.1 executable, merge one of the maintained host
-templates and point its command at the downloaded file:
+To configure manually, merge one of the maintained host templates and point
+its command at the included or separately downloaded `rookhold-cli` file:
 
 - [Claude Code template](https://github.com/sambai-dev/rookhold/blob/main/integrations/claude-code/mcp.json)
 - [OpenCode template](https://github.com/sambai-dev/rookhold/blob/main/integrations/opencode/opencode.snippet.json)
 - [Hermes template](https://github.com/sambai-dev/rookhold/blob/main/integrations/hermes/config.snippet.yaml)
 - [OpenClaw template](https://github.com/sambai-dev/rookhold/blob/main/integrations/openclaw/openclaw.snippet.json5)
 - [Generic MCP configuration](https://github.com/sambai-dev/rookhold/blob/main/integrations/README.md#generic-mcp-host)
-
-After v0.8.0 is released, the unified command can configure a maintained host
-for you:
-
-```bash
-rookhold setup claude-code
-rookhold setup hermes
-rookhold setup opencode
-```
-
-The command finds the normal configuration file, shows a diff, creates a
-timestamped backup, writes only after confirmation, keeps the API key in the
-environment, and runs `rookhold check` afterward.
 
 Adding Rookhold does not disable a host's built-in shell. Remove or deny other
 execution tools when a model must cross only the Rookhold boundary.

--- a/release.json
+++ b/release.json
@@ -1,10 +1,16 @@
 {
   "current_version": "0.8.0",
+  "release_status": "candidate",
   "release_url": "https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0",
   "windows_app_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip",
   "mac_app_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz",
   "linux_app_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz",
   "windows_client_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-pc-windows-msvc.exe",
   "mac_client_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin",
-  "linux_client_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu"
+  "linux_client_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu",
+  "python_wheel_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl",
+  "python_sdist_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tar.gz",
+  "npm_tarball_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz",
+  "spdx_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.spdx.json",
+  "checksums_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/SHA256SUMS"
 }

--- a/release.json
+++ b/release.json
@@ -1,0 +1,10 @@
+{
+  "current_version": "0.8.0",
+  "release_url": "https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0",
+  "windows_app_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip",
+  "mac_app_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz",
+  "linux_app_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz",
+  "windows_client_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-pc-windows-msvc.exe",
+  "mac_client_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-aarch64-apple-darwin",
+  "linux_client_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-cli-x86_64-unknown-linux-gnu"
+}

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -30,6 +30,8 @@ def check_release_data(version: str) -> dict[str, str]:
     """Validate the canonical public release URLs and consumer surfaces."""
     release_data = json.loads(read("release.json"))
     require(isinstance(release_data, dict), "release.json must contain an object")
+    release_status = release_data.get("release_status")
+    require(release_status in {"candidate", "current"}, "release.json has an invalid release_status")
     base = f"https://github.com/sambai-dev/rookhold/releases/download/v{version}"
     expected = {
         "current_version": version,
@@ -40,8 +42,14 @@ def check_release_data(version: str) -> dict[str, str]:
         "windows_client_url": f"{base}/rookhold-cli-x86_64-pc-windows-msvc.exe",
         "mac_client_url": f"{base}/rookhold-cli-aarch64-apple-darwin",
         "linux_client_url": f"{base}/rookhold-cli-x86_64-unknown-linux-gnu",
+        "python_wheel_url": f"{base}/rookhold-{version}-py3-none-any.whl",
+        "python_sdist_url": f"{base}/rookhold-{version}.tar.gz",
+        "npm_tarball_url": f"{base}/rookhold-{version}.tgz",
+        "spdx_url": f"{base}/rookhold-{version}.spdx.json",
+        "checksums_url": f"{base}/SHA256SUMS",
     }
-    require(release_data == expected, "release.json differs from the eleven-asset release contract")
+    actual_contract = {key: value for key, value in release_data.items() if key != "release_status"}
+    require(actual_contract == expected, "release.json differs from the eleven-asset release contract")
 
     consumer_surfaces = {
         "README.md": [
@@ -71,13 +79,36 @@ def check_release_data(version: str) -> dict[str, str]:
             expected["linux_app_url"],
         ],
         "docs/getting-started/installation.md": [
-            expected[key] for key in expected if key != "current_version"
+            expected[key]
+            for key in [
+                "release_url",
+                "windows_app_url",
+                "mac_app_url",
+                "linux_app_url",
+                "windows_client_url",
+                "mac_client_url",
+                "linux_client_url",
+            ]
+        ],
+        "docs/sdks.md": [
+            expected["python_wheel_url"],
+            expected["python_sdist_url"],
+            expected["npm_tarball_url"],
+            expected["spdx_url"],
+            expected["checksums_url"],
         ],
     }
     for relative, required_values in consumer_surfaces.items():
         source = read(relative)
         for required_value in required_values:
             require(required_value in source, f"{relative} differs from release.json: {required_value}")
+
+    if release_status == "candidate":
+        for relative in ["README.md", "docs/index.md"]:
+            require(
+                "release candidate" in read(relative).casefold(),
+                f"{relative} presents unpublished v{version} as current",
+            )
 
     for relative in [
         "README.md",

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -26,6 +26,77 @@ def require(condition: bool, message: str) -> None:
         raise AssertionError(message)
 
 
+def check_release_data(version: str) -> dict[str, str]:
+    """Validate the canonical public release URLs and consumer surfaces."""
+    release_data = json.loads(read("release.json"))
+    require(isinstance(release_data, dict), "release.json must contain an object")
+    base = f"https://github.com/sambai-dev/rookhold/releases/download/v{version}"
+    expected = {
+        "current_version": version,
+        "release_url": f"https://github.com/sambai-dev/rookhold/releases/tag/v{version}",
+        "windows_app_url": f"{base}/rookhold-x86_64-pc-windows-msvc.zip",
+        "mac_app_url": f"{base}/rookhold-aarch64-apple-darwin.tar.gz",
+        "linux_app_url": f"{base}/rookhold-x86_64-unknown-linux-musl.tar.gz",
+        "windows_client_url": f"{base}/rookhold-cli-x86_64-pc-windows-msvc.exe",
+        "mac_client_url": f"{base}/rookhold-cli-aarch64-apple-darwin",
+        "linux_client_url": f"{base}/rookhold-cli-x86_64-unknown-linux-gnu",
+    }
+    require(release_data == expected, "release.json differs from the eleven-asset release contract")
+
+    consumer_surfaces = {
+        "README.md": [
+            expected["release_url"],
+            expected["windows_app_url"],
+            expected["mac_app_url"],
+            expected["linux_app_url"],
+            expected["windows_client_url"],
+            expected["mac_client_url"],
+            expected["linux_client_url"],
+            "pip install rookhold",
+            "npm install rookhold",
+        ],
+        "docs/index.md": [
+            expected["windows_app_url"],
+            expected["mac_app_url"],
+            expected["linux_app_url"],
+            expected["windows_client_url"],
+            expected["mac_client_url"],
+            expected["linux_client_url"],
+            "pip install rookhold",
+            "npm install rookhold",
+        ],
+        "docs/getting-started/quickstart.md": [
+            expected["windows_app_url"],
+            expected["mac_app_url"],
+            expected["linux_app_url"],
+        ],
+        "docs/getting-started/installation.md": [
+            expected[key] for key in expected if key != "current_version"
+        ],
+    }
+    for relative, required_values in consumer_surfaces.items():
+        source = read(relative)
+        for required_value in required_values:
+            require(required_value in source, f"{relative} differs from release.json: {required_value}")
+
+    for relative in [
+        "README.md",
+        "docs/index.md",
+        "docs/getting-started/quickstart.md",
+        "docs/getting-started/installation.md",
+        "docs/use/cli.md",
+        "docs/use/mcp.md",
+        "sdks/python/README.md",
+        "sdks/typescript/README.md",
+    ]:
+        advertised_versions = set(re.findall(r"\bv(\d+\.\d+\.\d+)\b", read(relative)))
+        require(
+            advertised_versions <= {version},
+            f"{relative} advertises stale versions: {sorted(advertised_versions - {version})}",
+        )
+    return release_data
+
+
 def toml_string(relative: str, section: str, key: str) -> str:
     """Read one quoted TOML value without adding a Python-version dependency."""
     current = ""
@@ -46,6 +117,7 @@ def toml_string(relative: str, section: str, key: str) -> str:
 def check_versions() -> str:
     version = toml_string("Cargo.toml", "workspace.package", "version")
     require(version == "0.8.0", f"unexpected workspace release version: {version}")
+    check_release_data(version)
 
     toolchain = toml_string("rust-toolchain.toml", "toolchain", "channel")
     rust_version = toml_string("Cargo.toml", "workspace.package", "rust-version")
@@ -457,6 +529,8 @@ def check_pins_and_packaging() -> int:
         )
     require("os: macos-15" in release, "Apple-silicon release is not built on the GA arm64 runner")
     require("ROOKHOLD_RELEASE_GOVERNANCE" in release, "release workflow lacks repository-governance acknowledgement")
+    require("ROOKHOLD_PYPI_TRUSTED_PUBLISHER" in release, "release workflow lacks PyPI publisher acknowledgement")
+    require("ROOKHOLD_NPM_TRUSTED_PUBLISHER" in release, "release workflow lacks npm publisher acknowledgement")
     require(
         "environment:\n      name: release" in release,
         "publish job lacks the protected release environment hook",
@@ -763,6 +837,21 @@ def check_documented_boundary() -> None:
                 claim in document,
                 f"{relative} omits the current architecture boundary: {claim}",
             )
+    for relative in ["README.md", "docs/getting-started/quickstart.md"]:
+        source = read(relative)
+        for claim in ["network      host", "isolation    none"]:
+            require(claim in source, f"{relative} omits truthful local-demo output: {claim}")
+    compatibility = read(".github/workflows/compatibility.yml")
+    require(
+        "scripts/verify-local-demo.py local-demo.json" in compatibility,
+        "compatibility workflow does not execute the local documentation snapshot",
+    )
+    verifier = read("scripts/verify-local-demo.py")
+    for invariant in [
+        'receipt.get("networking") == "host"',
+        'receipt.get("isolation_class") == "none"',
+    ]:
+        require(invariant in verifier, f"local documentation verifier omits: {invariant}")
     service = read("deploy/rookhold.service")
     require(
         "ConditionArchitecture=x86-64" in service,

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -48,6 +48,20 @@ def check_release_status_language(
                 "release candidate" in surface_sources[relative].casefold(),
                 f"{relative} presents unpublished v{version} as current",
             )
+        forbidden_phrases = [
+            "current release",
+            "published release",
+            "now available",
+            f"v{version} is current",
+            f"v{version} is published",
+        ]
+        for relative, source in surface_sources.items():
+            folded = source.casefold()
+            for phrase in forbidden_phrases:
+                require(
+                    phrase not in folded,
+                    f"{relative} overstates candidate v{version} as published: {phrase}",
+                )
         return
 
     forbidden_phrases = [
@@ -89,9 +103,14 @@ def check_release_data(version: str) -> dict[str, str]:
     actual_contract = {key: value for key, value in release_data.items() if key != "release_status"}
     require(actual_contract == expected, "release.json differs from the eleven-asset release contract")
 
+    release_landing = (
+        expected["release_url"]
+        if release_status == "current"
+        else "https://github.com/sambai-dev/rookhold/releases"
+    )
     consumer_surfaces = {
         "README.md": [
-            expected["release_url"],
+            release_landing,
             expected["windows_app_url"],
             expected["mac_app_url"],
             expected["linux_app_url"],
@@ -359,19 +378,14 @@ def check_versions() -> str:
         "release workflow does not reject an unfinalized changelog",
     )
     require(
-        "[v${version}](https://github.com/sambai-dev/rookhold/releases/tag/v${version})"
+        'data.get("current_version") != sys.argv[1]'
         in release_workflow,
-        "release workflow does not require the matching README release link",
+        "release workflow does not require matching canonical release metadata",
     )
     require(
         'series="${version%.*}.x"' in release_workflow
         and "| tagged \\`${series}\\` releases | Supported |" in release_workflow,
         "release workflow does not require the matching supported-version line",
-    )
-    require(
-        f"[v{version}](https://github.com/sambai-dev/rookhold/releases/tag/v{version})"
-        in read("README.md"),
-        "README current-release link differs from the workspace version",
     )
     series = version.rsplit(".", 1)[0] + ".x"
     require(
@@ -876,6 +890,16 @@ def check_pins_and_packaging() -> int:
         "--draft=false" in publish_job,
         "release workflow must publish its draft only after registry smoke",
     )
+    for registry_contract in [
+        "scripts/reconcile-registries.py status",
+        "scripts/reconcile-registries.py verify",
+        "steps.registry-state.outputs.pypi == 'missing'",
+        "steps.registry-state.outputs.npm == 'missing'",
+    ]:
+        require(
+            registry_contract in registries_job,
+            f"registry retry reconciliation contract missing: {registry_contract}",
+        )
 
     install_docs = read("docs/deployment.md") + read("docs/sdks.md")
     require(
@@ -956,6 +980,11 @@ def check_documented_boundary() -> None:
     require(
         '.get(format!("{base_url}/readyz"))' in read("crates/coop-server/src/cli.rs"),
         "temporary app startup does not wait for durable readiness",
+    )
+    require(
+        'limits.insert("allow_network".into(), json!(false));'
+        in read("crates/coop-server/src/cli.rs"),
+        "unified CLI submissions must explicitly deny job networking",
     )
     service = read("deploy/rookhold.service")
     require(

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -233,6 +233,10 @@ def check_versions() -> str:
         typescript_source.count(typescript_client_header) == 2,
         "TypeScript HTTP and artifact clients do not identify the package release version",
     )
+    require(
+        'const moduleName = "node:crypto"' in typescript_source,
+        "TypeScript SDK omits the Node 18 Web Crypto fallback",
+    )
     python_lock = read("sdks/python/uv.lock")
     locked_python_project = re.search(
         r'\[\[package\]\]\s+name = "rookhold"\s+version = "([^"]+)"',
@@ -852,6 +856,10 @@ def check_documented_boundary() -> None:
         'receipt.get("isolation_class") == "none"',
     ]:
         require(invariant in verifier, f"local documentation verifier omits: {invariant}")
+    require(
+        '.get(format!("{base_url}/readyz"))' in read("crates/coop-server/src/cli.rs"),
+        "temporary app startup does not wait for durable readiness",
+    )
     service = read("deploy/rookhold.service")
     require(
         "ConditionArchitecture=x86-64" in service,

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -117,8 +117,8 @@ def check_release_data(version: str) -> dict[str, str]:
             expected["windows_client_url"],
             expected["mac_client_url"],
             expected["linux_client_url"],
-            "pip install rookhold",
-            "npm install rookhold",
+            expected["python_wheel_url"],
+            expected["npm_tarball_url"],
         ],
         "docs/index.md": [
             expected["windows_app_url"],
@@ -127,8 +127,7 @@ def check_release_data(version: str) -> dict[str, str]:
             expected["windows_client_url"],
             expected["mac_client_url"],
             expected["linux_client_url"],
-            "pip install rookhold",
-            "npm install rookhold",
+            "registry accounts are activated",
         ],
         "docs/getting-started/quickstart.md": [
             expected["windows_app_url"],
@@ -603,8 +602,23 @@ def check_pins_and_packaging() -> int:
         )
     require("os: macos-15" in release, "Apple-silicon release is not built on the GA arm64 runner")
     require("ROOKHOLD_RELEASE_GOVERNANCE" in release, "release workflow lacks repository-governance acknowledgement")
-    require("ROOKHOLD_PYPI_TRUSTED_PUBLISHER" in release, "release workflow lacks PyPI publisher acknowledgement")
-    require("ROOKHOLD_NPM_TRUSTED_PUBLISHER" in release, "release workflow lacks npm publisher acknowledgement")
+    require("ROOKHOLD_PYPI_TRUSTED_PUBLISHER" not in release, "binary release still blocks on PyPI activation")
+    require("ROOKHOLD_NPM_TRUSTED_PUBLISHER" not in release, "binary release still blocks on npm activation")
+    deferred_packages = read(".github/workflows/publish-packages.yml")
+    for deferred_contract in [
+        "workflow_dispatch:",
+        "gh release download",
+        "gh attestation verify",
+        "scripts/reconcile-registries.py status",
+        "scripts/reconcile-registries.py verify",
+        "pypa/gh-action-pypi-publish@",
+        "npm publish",
+        "environment:\n      name: release",
+    ]:
+        require(
+            deferred_contract in deferred_packages,
+            f"deferred package publisher contract missing: {deferred_contract}",
+        )
     require(
         "environment:\n      name: release" in release,
         "publish job lacks the protected release environment hook",
@@ -849,32 +863,26 @@ def check_pins_and_packaging() -> int:
     require(release.count("actions/attest@") == 2, "release workflow must create SBOM and provenance attestations")
     require("draft: true" in release, "release assets must stage in a draft")
     stage_start = release.find("\n  stage-release:")
-    registries_start = release.find("\n  publish-registries:")
-    smoke_start = release.find("\n  registry-smoke:")
+    package_start = release.find("\n  package-smoke:")
     publish_start = release.find("\n  publish-release:")
     require(
-        min(stage_start, registries_start, smoke_start, publish_start) >= 0,
+        min(stage_start, package_start, publish_start) >= 0,
         "release workflow omits one or more ordered publication jobs",
     )
     require(
-        stage_start < registries_start < smoke_start < publish_start,
-        "release jobs must stage, publish registries, smoke registries, then publish GitHub",
+        stage_start < package_start < publish_start,
+        "release jobs must stage, smoke exact packages, then publish GitHub",
     )
-    stage_job = release[stage_start:registries_start]
-    registries_job = release[registries_start:smoke_start]
-    smoke_job = release[smoke_start:publish_start]
+    stage_job = release[stage_start:package_start]
+    package_job = release[package_start:publish_start]
     publish_job = release[publish_start:]
     require(
-        "needs: [preflight, stage-release]" in registries_job,
-        "registry publication must depend on the reconciled draft",
+        "needs: [preflight, stage-release]" in package_job,
+        "package smoke must depend on the reconciled draft",
     )
     require(
-        "needs: [preflight, publish-registries]" in smoke_job,
-        "registry smoke must depend on public package publication",
-    )
-    require(
-        "needs: [preflight, stage-release, registry-smoke]" in publish_job,
-        "public GitHub release must depend on both the draft and registry smoke",
+        "needs: [preflight, stage-release, package-smoke]" in publish_job,
+        "public GitHub release must depend on both the draft and exact package smoke",
     )
     require(
         "name: rookhold-release-staged" in stage_job
@@ -888,18 +896,13 @@ def check_pins_and_packaging() -> int:
     require("--draft=false" not in stage_job, "draft staging must not publish the GitHub release")
     require(
         "--draft=false" in publish_job,
-        "release workflow must publish its draft only after registry smoke",
+        "release workflow must publish its draft only after exact package smoke",
     )
-    for registry_contract in [
-        "scripts/reconcile-registries.py status",
-        "scripts/reconcile-registries.py verify",
-        "steps.registry-state.outputs.pypi == 'missing'",
-        "steps.registry-state.outputs.npm == 'missing'",
+    for package_contract in [
+        "pip install --no-deps",
+        "npm install \"../sdk-dist/rookhold-${RELEASE_VERSION}.tgz\"",
     ]:
-        require(
-            registry_contract in registries_job,
-            f"registry retry reconciliation contract missing: {registry_contract}",
-        )
+        require(package_contract in package_job, f"release package smoke missing: {package_contract}")
 
     install_docs = read("docs/deployment.md") + read("docs/sdks.md")
     require(

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -16,6 +16,18 @@ from urllib.parse import unquote, urlsplit
 
 ROOT = Path(__file__).resolve().parents[1]
 
+CURRENT_CONSUMER_SURFACES = [
+    "README.md",
+    "docs/index.md",
+    "docs/getting-started/quickstart.md",
+    "docs/getting-started/installation.md",
+    "docs/use/cli.md",
+    "docs/use/mcp.md",
+    "docs/sdks.md",
+    "sdks/python/README.md",
+    "sdks/typescript/README.md",
+]
+
 
 def read(relative: str) -> str:
     return (ROOT / relative).read_text(encoding="utf-8")
@@ -24,6 +36,32 @@ def read(relative: str) -> str:
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise AssertionError(message)
+
+
+def check_release_status_language(
+    release_status: str, version: str, surface_sources: dict[str, str]
+) -> None:
+    """Keep candidate and current consumer copy aligned with release state."""
+    if release_status == "candidate":
+        for relative in ["README.md", "docs/index.md"]:
+            require(
+                "release candidate" in surface_sources[relative].casefold(),
+                f"{relative} presents unpublished v{version} as current",
+            )
+        return
+
+    forbidden_phrases = [
+        "release candidate",
+        f"after v{version} publishes",
+        "until then",
+    ]
+    for relative, source in surface_sources.items():
+        folded = source.casefold()
+        for phrase in forbidden_phrases:
+            require(
+                phrase not in folded,
+                f"{relative} retains pre-publication wording for current v{version}: {phrase}",
+            )
 
 
 def check_release_data(version: str) -> dict[str, str]:
@@ -103,24 +141,11 @@ def check_release_data(version: str) -> dict[str, str]:
         for required_value in required_values:
             require(required_value in source, f"{relative} differs from release.json: {required_value}")
 
-    if release_status == "candidate":
-        for relative in ["README.md", "docs/index.md"]:
-            require(
-                "release candidate" in read(relative).casefold(),
-                f"{relative} presents unpublished v{version} as current",
-            )
+    current_sources = {relative: read(relative) for relative in CURRENT_CONSUMER_SURFACES}
+    check_release_status_language(release_status, version, current_sources)
 
-    for relative in [
-        "README.md",
-        "docs/index.md",
-        "docs/getting-started/quickstart.md",
-        "docs/getting-started/installation.md",
-        "docs/use/cli.md",
-        "docs/use/mcp.md",
-        "sdks/python/README.md",
-        "sdks/typescript/README.md",
-    ]:
-        advertised_versions = set(re.findall(r"\bv(\d+\.\d+\.\d+)\b", read(relative)))
+    for relative, source in current_sources.items():
+        advertised_versions = set(re.findall(r"\bv(\d+\.\d+\.\d+)\b", source))
         require(
             advertised_versions <= {version},
             f"{relative} advertises stale versions: {sorted(advertised_versions - {version})}",
@@ -809,7 +834,48 @@ def check_pins_and_packaging() -> int:
     )
     require(release.count("actions/attest@") == 2, "release workflow must create SBOM and provenance attestations")
     require("draft: true" in release, "release assets must stage in a draft")
-    require("--draft=false" in release, "release workflow never atomically publishes its draft")
+    stage_start = release.find("\n  stage-release:")
+    registries_start = release.find("\n  publish-registries:")
+    smoke_start = release.find("\n  registry-smoke:")
+    publish_start = release.find("\n  publish-release:")
+    require(
+        min(stage_start, registries_start, smoke_start, publish_start) >= 0,
+        "release workflow omits one or more ordered publication jobs",
+    )
+    require(
+        stage_start < registries_start < smoke_start < publish_start,
+        "release jobs must stage, publish registries, smoke registries, then publish GitHub",
+    )
+    stage_job = release[stage_start:registries_start]
+    registries_job = release[registries_start:smoke_start]
+    smoke_job = release[smoke_start:publish_start]
+    publish_job = release[publish_start:]
+    require(
+        "needs: [preflight, stage-release]" in registries_job,
+        "registry publication must depend on the reconciled draft",
+    )
+    require(
+        "needs: [preflight, publish-registries]" in smoke_job,
+        "registry smoke must depend on public package publication",
+    )
+    require(
+        "needs: [preflight, stage-release, registry-smoke]" in publish_job,
+        "public GitHub release must depend on both the draft and registry smoke",
+    )
+    require(
+        "name: rookhold-release-staged" in stage_job
+        and "name: rookhold-release-staged" in publish_job,
+        "final publication must re-use the exact reconciled eleven-asset set",
+    )
+    require(
+        "scripts/release-artifacts.py verify-release" in publish_job,
+        "final publication must re-verify the unchanged remote draft",
+    )
+    require("--draft=false" not in stage_job, "draft staging must not publish the GitHub release")
+    require(
+        "--draft=false" in publish_job,
+        "release workflow must publish its draft only after registry smoke",
+    )
 
     install_docs = read("docs/deployment.md") + read("docs/sdks.md")
     require(

--- a/scripts/reconcile-registries.py
+++ b/scripts/reconcile-registries.py
@@ -12,11 +12,21 @@ from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import quote, urlsplit
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 MAX_METADATA_BYTES = 4 * 1024 * 1024
 MAX_PACKAGE_BYTES = 64 * 1024 * 1024
 USER_AGENT = "rookhold-release-reconciler/0.8"
+
+
+class RejectRedirects(HTTPRedirectHandler):
+    """Prevent a registry response from connecting to an unvalidated target."""
+
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        return None
+
+
+OPEN_URL = build_opener(RejectRedirects()).open
 
 
 def require(condition: bool, message: str) -> None:
@@ -53,7 +63,7 @@ def fetch(
 ) -> bytes | None:
     request = Request(url, headers={"Accept": "application/json", "User-Agent": USER_AGENT})
     try:
-        response = urlopen(request, timeout=30)
+        response = OPEN_URL(request, timeout=30)
     except HTTPError as error:
         if allow_missing and error.code == 404:
             return None
@@ -85,10 +95,18 @@ def fetch_json(
     if content is None:
         return None
     try:
-        value = json.loads(content)
+        value = json.loads(content, object_pairs_hook=reject_duplicate_members)
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError(f"registry returned malformed JSON: {url}") from error
     require(isinstance(value, dict), f"registry returned a non-object: {url}")
+    return value
+
+
+def reject_duplicate_members(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, member in pairs:
+        require(key not in value, f"registry JSON duplicates member: {key}")
+        value[key] = member
     return value
 
 

--- a/scripts/reconcile-registries.py
+++ b/scripts/reconcile-registries.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Reconcile public registry packages against exact local release bytes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote, urlsplit
+from urllib.request import Request, urlopen
+
+MAX_METADATA_BYTES = 4 * 1024 * 1024
+MAX_PACKAGE_BYTES = 64 * 1024 * 1024
+USER_AGENT = "rookhold-release-reconciler/0.8"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def require_version(version: str) -> None:
+    require(
+        re.fullmatch(r"(?:0|[1-9][0-9]*)(?:\.(?:0|[1-9][0-9]*)){2}", version)
+        is not None,
+        f"invalid release version: {version!r}",
+    )
+
+
+def sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fetch(
+    url: str,
+    limit: int,
+    *,
+    allow_missing: bool = False,
+    expected_host: str,
+) -> bytes | None:
+    request = Request(url, headers={"Accept": "application/json", "User-Agent": USER_AGENT})
+    try:
+        response = urlopen(request, timeout=30)
+    except HTTPError as error:
+        if allow_missing and error.code == 404:
+            return None
+        raise ValueError(f"registry request failed with HTTP {error.code}: {url}") from error
+    with response:
+        final_url = response.geturl()
+        final = urlsplit(final_url)
+        require(
+            final.scheme == "https"
+            and final.hostname == expected_host
+            and final.username is None
+            and final.password is None,
+            f"registry response left its trusted HTTPS origin: {final_url}",
+        )
+        content = response.read(limit + 1)
+    require(len(content) <= limit, f"registry response exceeded {limit} bytes: {url}")
+    return content
+
+
+def fetch_json(
+    url: str, *, allow_missing: bool = False, expected_host: str
+) -> dict[str, Any] | None:
+    content = fetch(
+        url,
+        MAX_METADATA_BYTES,
+        allow_missing=allow_missing,
+        expected_host=expected_host,
+    )
+    if content is None:
+        return None
+    try:
+        value = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"registry returned malformed JSON: {url}") from error
+    require(isinstance(value, dict), f"registry returned a non-object: {url}")
+    return value
+
+
+def required_file(path: Path) -> Path:
+    require(path.is_file() and not path.is_symlink(), f"local package is missing: {path}")
+    require(path.stat().st_size > 0, f"local package is empty: {path}")
+    return path
+
+
+def pypi_state(version: str, dist: Path) -> str:
+    expected_paths = {
+        f"rookhold-{version}-py3-none-any.whl": required_file(
+            dist / f"rookhold-{version}-py3-none-any.whl"
+        ),
+        f"rookhold-{version}.tar.gz": required_file(dist / f"rookhold-{version}.tar.gz"),
+    }
+    metadata = fetch_json(
+        f"https://pypi.org/pypi/rookhold/{quote(version, safe='')}/json",
+        allow_missing=True,
+        expected_host="pypi.org",
+    )
+    if metadata is None:
+        return "missing"
+    urls = metadata.get("urls")
+    require(isinstance(urls, list), "PyPI metadata omits release files")
+    remote: dict[str, str] = {}
+    for item in urls:
+        require(isinstance(item, dict), "PyPI metadata contains a malformed file")
+        filename = item.get("filename")
+        digests = item.get("digests")
+        require(isinstance(filename, str), "PyPI file omits its filename")
+        require(isinstance(digests, dict), f"PyPI file omits digests: {filename}")
+        digest = digests.get("sha256")
+        require(
+            isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest) is not None,
+            f"PyPI file has an invalid SHA-256: {filename}",
+        )
+        require(filename not in remote, f"PyPI metadata duplicates a filename: {filename}")
+        remote[filename] = digest
+    require(
+        set(remote) == set(expected_paths),
+        f"PyPI v{version} file set differs: remote={sorted(remote)}",
+    )
+    for filename, path in expected_paths.items():
+        require(
+            remote[filename] == sha256_file(path),
+            f"PyPI v{version} digest differs for {filename}",
+        )
+    return "exact"
+
+
+def npm_state(version: str, dist: Path) -> str:
+    local = required_file(dist / f"rookhold-{version}.tgz")
+    metadata = fetch_json(
+        f"https://registry.npmjs.org/rookhold/{quote(version, safe='')}",
+        allow_missing=True,
+        expected_host="registry.npmjs.org",
+    )
+    if metadata is None:
+        return "missing"
+    require(metadata.get("name") == "rookhold", "npm metadata returned the wrong package")
+    require(metadata.get("version") == version, "npm metadata returned the wrong version")
+    distribution = metadata.get("dist")
+    require(isinstance(distribution, dict), "npm metadata omits dist")
+    tarball = distribution.get("tarball")
+    require(isinstance(tarball, str), "npm metadata omits the tarball URL")
+    parsed = urlsplit(tarball)
+    require(
+        parsed.scheme == "https"
+        and parsed.hostname == "registry.npmjs.org"
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.query == ""
+        and parsed.fragment == "",
+        "npm tarball URL is outside the public registry",
+    )
+    remote = fetch(tarball, MAX_PACKAGE_BYTES, expected_host="registry.npmjs.org")
+    assert remote is not None
+    require(
+        sha256_bytes(remote) == sha256_file(local),
+        f"npm rookhold@{version} tarball digest differs from the gated package",
+    )
+    return "exact"
+
+
+def registry_state(registry: str, version: str, dist: Path) -> str:
+    require_version(version)
+    if registry == "pypi":
+        return pypi_state(version, dist)
+    if registry == "npm":
+        return npm_state(version, dist)
+    raise ValueError(f"unsupported registry: {registry}")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    subparsers = root.add_subparsers(dest="command", required=True)
+    for command in ["status", "verify"]:
+        child = subparsers.add_parser(command)
+        child.add_argument("--registry", choices=["pypi", "npm"], required=True)
+        child.add_argument("--version", required=True)
+        child.add_argument("--dist", type=Path, required=True)
+        if command == "verify":
+            child.add_argument("--attempts", type=int, default=12)
+            child.add_argument("--delay-seconds", type=float, default=5.0)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        if args.command == "status":
+            print(registry_state(args.registry, args.version, args.dist))
+            return 0
+        require(args.attempts > 0, "verify attempts must be positive")
+        require(args.delay_seconds >= 0, "verify delay must be non-negative")
+        for attempt in range(1, args.attempts + 1):
+            state = registry_state(args.registry, args.version, args.dist)
+            if state == "exact":
+                print(f"{args.registry} v{args.version} matches the gated package bytes")
+                return 0
+            if attempt < args.attempts:
+                time.sleep(args.delay_seconds)
+        raise ValueError(
+            f"{args.registry} v{args.version} remained missing after {args.attempts} checks"
+        )
+    except (OSError, ValueError) as error:
+        print(f"registry reconciliation failed: {error}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_reconcile_registries.py
+++ b/scripts/tests/test_reconcile_registries.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import runpy
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = runpy.run_path(str(ROOT / "scripts" / "reconcile-registries.py"))
+
+
+class Response(io.BytesIO):
+    def __init__(self, content: bytes, url: str) -> None:
+        super().__init__(content)
+        self._url = url
+
+    def geturl(self) -> str:
+        return self._url
+
+
+def json_response(value: object, url: str) -> Response:
+    return Response(json.dumps(value).encode(), url)
+
+
+class RegistryReconciliationTests(unittest.TestCase):
+    VERSION = "0.8.0"
+
+    def make_dist(self, directory: str) -> tuple[Path, dict[str, bytes]]:
+        dist = Path(directory)
+        content = {
+            f"rookhold-{self.VERSION}-py3-none-any.whl": b"wheel-bytes",
+            f"rookhold-{self.VERSION}.tar.gz": b"sdist-bytes",
+            f"rookhold-{self.VERSION}.tgz": b"npm-bytes",
+        }
+        for name, value in content.items():
+            (dist / name).write_bytes(value)
+        return dist, content
+
+    def test_missing_version_is_safe_to_publish(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dist, _ = self.make_dist(directory)
+            missing = HTTPError("https://registry.example", 404, "missing", {}, None)
+            with patch.dict(MODULE["registry_state"].__globals__, {"urlopen": lambda *_a, **_k: (_ for _ in ()).throw(missing)}):
+                self.assertEqual(MODULE["registry_state"]("pypi", self.VERSION, dist), "missing")
+                self.assertEqual(MODULE["registry_state"]("npm", self.VERSION, dist), "missing")
+
+    def test_pypi_requires_the_exact_file_set_and_digests(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dist, content = self.make_dist(directory)
+            files = [
+                {"filename": name, "digests": {"sha256": hashlib.sha256(value).hexdigest()}}
+                for name, value in content.items()
+                if name.endswith((".whl", ".tar.gz"))
+            ]
+            url = f"https://pypi.org/pypi/rookhold/{self.VERSION}/json"
+            with patch.dict(
+                MODULE["registry_state"].__globals__,
+                {"urlopen": lambda *_a, **_k: json_response({"urls": files}, url)},
+            ):
+                self.assertEqual(MODULE["registry_state"]("pypi", self.VERSION, dist), "exact")
+                files[0]["digests"]["sha256"] = "0" * 64
+                with self.assertRaisesRegex(ValueError, "digest differs"):
+                    MODULE["registry_state"]("pypi", self.VERSION, dist)
+
+    def test_npm_downloads_and_compares_the_actual_tarball(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dist, content = self.make_dist(directory)
+            metadata_url = f"https://registry.npmjs.org/rookhold/{self.VERSION}"
+            tarball_url = f"https://registry.npmjs.org/rookhold/-/rookhold-{self.VERSION}.tgz"
+
+            def open_exact(request, **_kwargs):
+                if request.full_url == metadata_url:
+                    return json_response(
+                        {
+                            "name": "rookhold",
+                            "version": self.VERSION,
+                            "dist": {"tarball": tarball_url},
+                        },
+                        metadata_url,
+                    )
+                return Response(content[f"rookhold-{self.VERSION}.tgz"], tarball_url)
+
+            with patch.dict(MODULE["registry_state"].__globals__, {"urlopen": open_exact}):
+                self.assertEqual(MODULE["registry_state"]("npm", self.VERSION, dist), "exact")
+
+                def open_mismatch(request, **_kwargs):
+                    response = open_exact(request)
+                    return Response(b"different", tarball_url) if request.full_url == tarball_url else response
+
+                with patch.dict(MODULE["registry_state"].__globals__, {"urlopen": open_mismatch}):
+                    with self.assertRaisesRegex(ValueError, "digest differs"):
+                        MODULE["registry_state"]("npm", self.VERSION, dist)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_reconcile_registries.py
+++ b/scripts/tests/test_reconcile_registries.py
@@ -45,7 +45,7 @@ class RegistryReconciliationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             dist, _ = self.make_dist(directory)
             missing = HTTPError("https://registry.example", 404, "missing", {}, None)
-            with patch.dict(MODULE["registry_state"].__globals__, {"urlopen": lambda *_a, **_k: (_ for _ in ()).throw(missing)}):
+            with patch.dict(MODULE["registry_state"].__globals__, {"OPEN_URL": lambda *_a, **_k: (_ for _ in ()).throw(missing)}):
                 self.assertEqual(MODULE["registry_state"]("pypi", self.VERSION, dist), "missing")
                 self.assertEqual(MODULE["registry_state"]("npm", self.VERSION, dist), "missing")
 
@@ -60,11 +60,14 @@ class RegistryReconciliationTests(unittest.TestCase):
             url = f"https://pypi.org/pypi/rookhold/{self.VERSION}/json"
             with patch.dict(
                 MODULE["registry_state"].__globals__,
-                {"urlopen": lambda *_a, **_k: json_response({"urls": files}, url)},
+                {"OPEN_URL": lambda *_a, **_k: json_response({"urls": files}, url)},
             ):
                 self.assertEqual(MODULE["registry_state"]("pypi", self.VERSION, dist), "exact")
                 files[0]["digests"]["sha256"] = "0" * 64
                 with self.assertRaisesRegex(ValueError, "digest differs"):
+                    MODULE["registry_state"]("pypi", self.VERSION, dist)
+                files.pop()
+                with self.assertRaisesRegex(ValueError, "file set differs"):
                     MODULE["registry_state"]("pypi", self.VERSION, dist)
 
     def test_npm_downloads_and_compares_the_actual_tarball(self) -> None:
@@ -85,16 +88,32 @@ class RegistryReconciliationTests(unittest.TestCase):
                     )
                 return Response(content[f"rookhold-{self.VERSION}.tgz"], tarball_url)
 
-            with patch.dict(MODULE["registry_state"].__globals__, {"urlopen": open_exact}):
+            with patch.dict(MODULE["registry_state"].__globals__, {"OPEN_URL": open_exact}):
                 self.assertEqual(MODULE["registry_state"]("npm", self.VERSION, dist), "exact")
 
                 def open_mismatch(request, **_kwargs):
                     response = open_exact(request)
                     return Response(b"different", tarball_url) if request.full_url == tarball_url else response
 
-                with patch.dict(MODULE["registry_state"].__globals__, {"urlopen": open_mismatch}):
+                with patch.dict(MODULE["registry_state"].__globals__, {"OPEN_URL": open_mismatch}):
                     with self.assertRaisesRegex(ValueError, "digest differs"):
                         MODULE["registry_state"]("npm", self.VERSION, dist)
+
+    def test_registry_json_rejects_duplicate_members_at_any_depth(self) -> None:
+        url = "https://pypi.org/pypi/rookhold/0.8.0/json"
+        duplicate = b'{"urls":[],"nested":{"sha256":"a","sha256":"b"}}'
+        with patch.dict(
+            MODULE["fetch_json"].__globals__,
+            {"OPEN_URL": lambda *_a, **_k: Response(duplicate, url)},
+        ):
+            with self.assertRaisesRegex(ValueError, "duplicates member: sha256"):
+                MODULE["fetch_json"](url, expected_host="pypi.org")
+
+    def test_redirect_handler_refuses_every_redirect_target(self) -> None:
+        handler = MODULE["RejectRedirects"]()
+        self.assertIsNone(
+            handler.redirect_request(None, None, 302, "redirect", {}, "https://other.test")
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release_status_language.py
+++ b/scripts/tests/test_release_status_language.py
@@ -30,6 +30,18 @@ class ReleaseStatusLanguageTests(unittest.TestCase):
                 },
             )
 
+    def test_candidate_rejects_published_wording_on_a_secondary_surface(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "overstates candidate"):
+            CHECK_STATUS(
+                "candidate",
+                "0.8.0",
+                {
+                    "README.md": "Rookhold v0.8.0 release candidate",
+                    "docs/index.md": "v0.8.0 release candidate",
+                    "docs/sdks.md": "The current release is v0.8.0.",
+                },
+            )
+
     def test_current_rejects_every_prepublication_phrase(self) -> None:
         for phrase in [
             "release candidate",

--- a/scripts/tests/test_release_status_language.py
+++ b/scripts/tests/test_release_status_language.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import runpy
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = runpy.run_path(str(ROOT / "scripts" / "check-release-surface.py"))
+CHECK_STATUS = CHECKER["check_release_status_language"]
+
+
+class ReleaseStatusLanguageTests(unittest.TestCase):
+    def test_candidate_requires_an_explicit_warning_on_primary_surfaces(self) -> None:
+        CHECK_STATUS(
+            "candidate",
+            "0.8.0",
+            {
+                "README.md": "Rookhold v0.8.0 release candidate",
+                "docs/index.md": "v0.8.0 release candidate",
+            },
+        )
+
+        with self.assertRaisesRegex(AssertionError, "presents unpublished"):
+            CHECK_STATUS(
+                "candidate",
+                "0.8.0",
+                {
+                    "README.md": "Rookhold v0.8.0",
+                    "docs/index.md": "v0.8.0 release candidate",
+                },
+            )
+
+    def test_current_rejects_every_prepublication_phrase(self) -> None:
+        for phrase in [
+            "release candidate",
+            "after v0.8.0 publishes",
+            "until then",
+        ]:
+            with self.subTest(phrase=phrase):
+                with self.assertRaisesRegex(AssertionError, "pre-publication wording"):
+                    CHECK_STATUS(
+                        "current",
+                        "0.8.0",
+                        {"README.md": f"Install v0.8.0; {phrase}."},
+                    )
+
+    def test_current_accepts_stable_release_copy(self) -> None:
+        CHECK_STATUS(
+            "current",
+            "0.8.0",
+            {"README.md": "Install the current Rookhold v0.8.0 release."},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_verify_local_demo.py
+++ b/scripts/tests/test_verify_local_demo.py
@@ -50,6 +50,18 @@ class VerifyLocalDemoTests(unittest.TestCase):
                     with self.assertRaisesRegex(AssertionError, "result omits its job_id"):
                         MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
 
+    def test_rejects_non_host_networking_independently(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            payload = self.payload(root)
+            payload["receipt"] = {
+                "networking": "disabled",
+                "isolation_class": "none",
+                "job_id": self.JOB_ID,
+            }
+            with self.assertRaisesRegex(AssertionError, "host networking"):
+                MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
+
     def test_rejects_mismatched_receipt_job_id(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / ".rookhold" / "runs"

--- a/scripts/tests/test_verify_local_demo.py
+++ b/scripts/tests/test_verify_local_demo.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -13,24 +15,82 @@ SPEC.loader.exec_module(MODULE)
 
 
 class VerifyLocalDemoTests(unittest.TestCase):
-    def payload(self) -> dict[str, object]:
+    JOB_ID = "01900000-0000-7000-8000-000000000001"
+    OTHER_JOB_ID = "01900000-0000-7000-8000-000000000002"
+
+    def payload(self, runs_root: Path) -> dict[str, object]:
         return {
-            "result": {"status": "succeeded", "stdout": "42"},
-            "receipt": {"networking": "host", "isolation_class": "none"},
-            "receipt_path": ".rookhold/runs/example/receipt.json",
+            "result": {"status": "succeeded", "stdout": "42", "job_id": self.JOB_ID},
+            "receipt": {
+                "networking": "host",
+                "isolation_class": "none",
+                "job_id": self.JOB_ID,
+            },
+            "receipt_path": str(runs_root / self.JOB_ID / "receipt.json"),
         }
 
     def test_accepts_truthful_local_snapshot(self) -> None:
-        MODULE.verify(self.payload(), require_receipt_file=False)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            MODULE.verify(
+                self.payload(root), expected_runs_root=root, require_receipt_file=False
+            )
 
     def test_rejects_false_gvisor_claim(self) -> None:
-        payload = self.payload()
-        payload["receipt"] = {
-            "networking": "disabled",
-            "isolation_class": "gvisor-application-kernel",
-        }
-        with self.assertRaisesRegex(AssertionError, "host networking"):
-            MODULE.verify(payload, require_receipt_file=False)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            payload = self.payload(root)
+            payload["receipt"] = {
+                "networking": "host",
+                "isolation_class": "gvisor-application-kernel",
+                "job_id": self.JOB_ID,
+            }
+            with self.assertRaisesRegex(AssertionError, "isolation none"):
+                MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
+
+    def test_rejects_out_of_tree_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            root = base / ".rookhold" / "runs"
+            payload = self.payload(root)
+            payload["receipt_path"] = str(base / "outside" / "receipt.json")
+            with self.assertRaisesRegex(AssertionError, "escapes"):
+                MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
+
+    def test_rejects_stale_receipt_from_another_job(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            payload = self.payload(root)
+            payload["receipt_path"] = str(root / self.OTHER_JOB_ID / "receipt.json")
+            with self.assertRaisesRegex(AssertionError, "stale"):
+                MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
+
+    def test_rejects_traversal_receipt_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            payload = self.payload(root)
+            payload["receipt_path"] = str(
+                root / self.JOB_ID / ".." / self.OTHER_JOB_ID / "receipt.json"
+            )
+            with self.assertRaisesRegex(AssertionError, "traversal"):
+                MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
+
+    def test_rejects_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            root = base / ".rookhold" / "runs"
+            job_dir = root / self.JOB_ID
+            job_dir.mkdir(parents=True)
+            outside = base / "outside-receipt.json"
+            outside.write_text("{}", encoding="utf-8")
+            link = job_dir / "receipt.json"
+            try:
+                os.symlink(outside, link)
+            except OSError as error:
+                self.skipTest(f"symlink unavailable: {error}")
+            payload = self.payload(root)
+            with self.assertRaisesRegex(AssertionError, "escapes"):
+                MODULE.verify(payload, expected_runs_root=root)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_verify_local_demo.py
+++ b/scripts/tests/test_verify_local_demo.py
@@ -29,12 +29,73 @@ class VerifyLocalDemoTests(unittest.TestCase):
             "receipt_path": str(runs_root / self.JOB_ID / "receipt.json"),
         }
 
+    def write_receipt(self, runs_root: Path) -> None:
+        receipt = runs_root / self.JOB_ID / "receipt.json"
+        receipt.parent.mkdir(parents=True)
+        receipt.write_text("{}", encoding="utf-8")
+
     def test_accepts_truthful_local_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / ".rookhold" / "runs"
-            MODULE.verify(
-                self.payload(root), expected_runs_root=root, require_receipt_file=False
-            )
+            self.write_receipt(root)
+            MODULE.verify(self.payload(root), expected_runs_root=root)
+
+    def test_rejects_missing_or_non_string_result_job_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            for value in [None, 7]:
+                with self.subTest(value=value):
+                    payload = self.payload(root)
+                    payload["result"] = {"status": "succeeded", "stdout": "42", "job_id": value}
+                    with self.assertRaisesRegex(AssertionError, "result omits its job_id"):
+                        MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
+
+    def test_rejects_mismatched_receipt_job_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            payload = self.payload(root)
+            payload["receipt"] = {
+                "networking": "host",
+                "isolation_class": "none",
+                "job_id": self.OTHER_JOB_ID,
+            }
+            with self.assertRaisesRegex(AssertionError, "job IDs differ"):
+                MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
+
+    def test_rejects_non_uuidv7_job_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            payload = self.payload(root)
+            uuidv4 = "123e4567-e89b-42d3-a456-426614174000"
+            payload["result"] = {"status": "succeeded", "stdout": "42", "job_id": uuidv4}
+            payload["receipt"] = {
+                "networking": "host",
+                "isolation_class": "none",
+                "job_id": uuidv4,
+            }
+            payload["receipt_path"] = str(root / uuidv4 / "receipt.json")
+            with self.assertRaisesRegex(AssertionError, "not UUIDv7"):
+                MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
+
+    def test_rejects_each_malformed_receipt_path_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".rookhold" / "runs"
+            cases = {
+                "missing": None,
+                "empty": "",
+                "nul": "receipt\x00.json",
+                "unexpected": str(root / self.JOB_ID / "result.json"),
+            }
+            for name, value in cases.items():
+                with self.subTest(name=name):
+                    payload = self.payload(root)
+                    if value is None:
+                        payload.pop("receipt_path")
+                    else:
+                        payload["receipt_path"] = value
+                    expected = "did not save" if name == "missing" else "malformed|unexpected"
+                    with self.assertRaisesRegex(AssertionError, expected):
+                        MODULE.verify(payload, expected_runs_root=root, require_receipt_file=False)
 
     def test_rejects_false_gvisor_claim(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/tests/test_verify_local_demo.py
+++ b/scripts/tests/test_verify_local_demo.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "verify-local-demo.py"
+SPEC = importlib.util.spec_from_file_location("verify_local_demo", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VerifyLocalDemoTests(unittest.TestCase):
+    def payload(self) -> dict[str, object]:
+        return {
+            "result": {"status": "succeeded", "stdout": "42"},
+            "receipt": {"networking": "host", "isolation_class": "none"},
+            "receipt_path": ".rookhold/runs/example/receipt.json",
+        }
+
+    def test_accepts_truthful_local_snapshot(self) -> None:
+        MODULE.verify(self.payload(), require_receipt_file=False)
+
+    def test_rejects_false_gvisor_claim(self) -> None:
+        payload = self.payload()
+        payload["receipt"] = {
+            "networking": "disabled",
+            "isolation_class": "gvisor-application-kernel",
+        }
+        with self.assertRaisesRegex(AssertionError, "host networking"):
+            MODULE.verify(payload, require_receipt_file=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-local-demo.py
+++ b/scripts/verify-local-demo.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
+from uuid import UUID
 
 
 def require(condition: bool, message: str) -> None:
@@ -14,7 +15,12 @@ def require(condition: bool, message: str) -> None:
         raise AssertionError(message)
 
 
-def verify(payload: dict[str, Any], *, require_receipt_file: bool = True) -> None:
+def verify(
+    payload: dict[str, Any],
+    *,
+    expected_runs_root: Optional[Path] = None,
+    require_receipt_file: bool = True,
+) -> None:
     result = payload.get("result")
     receipt = payload.get("receipt")
     require(isinstance(result, dict), "local demo JSON omits result")
@@ -23,11 +29,36 @@ def verify(payload: dict[str, Any], *, require_receipt_file: bool = True) -> Non
     require(result.get("stdout") == "42", "local demo stdout differs from the documentation")
     require(receipt.get("networking") == "host", "local demo must report host networking")
     require(receipt.get("isolation_class") == "none", "local demo must report isolation none")
+    result_job_id = result.get("job_id")
+    receipt_job_id = receipt.get("job_id")
+    require(isinstance(result_job_id, str), "local demo result omits its job_id")
+    require(receipt_job_id == result_job_id, "local demo result and receipt job IDs differ")
+    try:
+        parsed_job_id = UUID(result_job_id)
+    except (ValueError, AttributeError) as error:
+        raise AssertionError("local demo job_id is not a UUID") from error
+    require(parsed_job_id.version == 7, "local demo job_id is not UUIDv7")
+
     receipt_path = payload.get("receipt_path")
     require(isinstance(receipt_path, str), "local demo did not save a receipt")
-    require(Path(receipt_path).name == "receipt.json", "local demo receipt path is unexpected")
+    require(receipt_path != "" and "\x00" not in receipt_path, "local demo receipt path is malformed")
+    reported_path = Path(receipt_path)
+    require(".." not in reported_path.parts, "local demo receipt path contains traversal")
+    require(reported_path.name == "receipt.json", "local demo receipt path is unexpected")
+
+    root = (expected_runs_root or (Path.cwd() / ".rookhold" / "runs")).resolve()
+    candidate = reported_path if reported_path.is_absolute() else Path.cwd() / reported_path
+    try:
+        resolved = candidate.resolve(strict=require_receipt_file)
+        relative = resolved.relative_to(root)
+    except (OSError, ValueError) as error:
+        raise AssertionError("local demo receipt path escapes .rookhold/runs") from error
+    require(
+        relative.parts == (result_job_id, "receipt.json"),
+        "local demo receipt path is stale or belongs to another job",
+    )
     if require_receipt_file:
-        require(Path(receipt_path).is_file(), "local demo receipt file does not exist")
+        require(resolved.is_file(), "local demo receipt file does not exist")
 
 
 def main() -> int:

--- a/scripts/verify-local-demo.py
+++ b/scripts/verify-local-demo.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Verify that the documented zero-configuration demo reports no containment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def verify(payload: dict[str, Any], *, require_receipt_file: bool = True) -> None:
+    result = payload.get("result")
+    receipt = payload.get("receipt")
+    require(isinstance(result, dict), "local demo JSON omits result")
+    require(isinstance(receipt, dict), "local demo JSON omits receipt")
+    require(result.get("status") == "succeeded", "local demo did not succeed")
+    require(result.get("stdout") == "42", "local demo stdout differs from the documentation")
+    require(receipt.get("networking") == "host", "local demo must report host networking")
+    require(receipt.get("isolation_class") == "none", "local demo must report isolation none")
+    receipt_path = payload.get("receipt_path")
+    require(isinstance(receipt_path, str), "local demo did not save a receipt")
+    require(Path(receipt_path).name == "receipt.json", "local demo receipt path is unexpected")
+    if require_receipt_file:
+        require(Path(receipt_path).is_file(), "local demo receipt file does not exist")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result", type=Path, help="JSON emitted by `rookhold run --json`")
+    args = parser.parse_args()
+    payload = json.loads(args.result.read_text(encoding="utf-8"))
+    require(isinstance(payload, dict), "local demo output must be a JSON object")
+    verify(payload)
+    print("local demo snapshot OK: status=succeeded network=host isolation=none")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -4,7 +4,13 @@ A typed synchronous client and stdio MCP adapter with no required dependencies.
 Install the optional stream extra for a native WebSocket; otherwise `stream()`
 transparently uses cursor replay.
 
-Install from PyPI:
+Before v0.8.0 publishes, install from the checkout:
+
+```bash
+python -m pip install "./sdks/python[stream]"
+```
+
+After publication, install from PyPI:
 
 ```bash
 python -m pip install "rookhold[stream]"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -4,14 +4,11 @@ A typed synchronous client and stdio MCP adapter with no required dependencies.
 Install the optional stream extra for a native WebSocket; otherwise `stream()`
 transparently uses cursor replay.
 
-Install from the current checkout:
+Install from PyPI:
 
 ```bash
-python -m pip install "./sdks/python[stream]"
+python -m pip install "rookhold[stream]"
 ```
-
-`python -m pip install "rookhold[stream]"` becomes available when v0.8.0 is
-published to PyPI.
 
 The common path is one call:
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -10,11 +10,13 @@ Before v0.8.0 publishes, install from the checkout:
 python -m pip install "./sdks/python[stream]"
 ```
 
-After publication, install from PyPI:
+After publication, install the exact release wheel:
 
 ```bash
-python -m pip install "rookhold[stream]"
+python -m pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl
 ```
+
+The named PyPI install is deferred until maintainer registry activation.
 
 The common path is one call:
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -9,7 +9,15 @@ permissive CORS headers; a cross-origin frontend needs an explicitly
 allowlisted reverse-proxy policy, and its bearer key will be available to that
 frontend's JavaScript.
 
-Install from npm:
+Before v0.8.0 publishes, build and pack the checkout:
+
+```bash
+cd sdks/typescript
+npm ci
+npm pack
+```
+
+After publication, install from npm:
 
 ```bash
 npm install rookhold

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -17,11 +17,14 @@ npm ci
 npm pack
 ```
 
-After publication, install from npm:
+After publication, install the exact release tarball:
 
 ```bash
-npm install rookhold
+npm install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz
 ```
+
+The named npm install is deferred until maintainer 2FA and trusted publishing
+are configured.
 
 The common path is one call:
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -9,15 +9,11 @@ permissive CORS headers; a cross-origin frontend needs an explicitly
 allowlisted reverse-proxy policy, and its bearer key will be available to that
 frontend's JavaScript.
 
-Build and pack the current checkout:
+Install from npm:
 
 ```bash
-cd sdks/typescript
-npm ci
-npm pack
+npm install rookhold
 ```
-
-`npm install rookhold` becomes available when v0.8.0 is published to npm.
 
 The common path is one call:
 

--- a/sdks/typescript/rookhold.ts
+++ b/sdks/typescript/rookhold.ts
@@ -798,7 +798,22 @@ async function messageText(value: unknown): Promise<string> {
 }
 
 async function sha256Hex(bytes: Uint8Array): Promise<string> {
-  const subtle = globalThis.crypto?.subtle;
+  let subtle: SubtleCrypto | undefined = globalThis.crypto?.subtle;
+  if (!subtle) {
+    try {
+      // Node 18 exposes Web Crypto through its built-in module rather than the
+      // global used by newer Node releases and browsers. Keep the specifier
+      // indirect so browser builds do not resolve a Node-only module eagerly.
+      const moduleName = "node:crypto";
+      const nodeCrypto = (await import(moduleName)) as {
+        webcrypto?: { subtle?: SubtleCrypto };
+      };
+      subtle = nodeCrypto.webcrypto?.subtle;
+    } catch {
+      // The closed error below remains the contract for runtimes with neither
+      // browser Web Crypto nor Node's built-in implementation.
+    }
+  }
   if (!subtle) {
     throw new RookholdError("this runtime does not provide Web Crypto SHA-256", {
       code: "digest_unavailable",

--- a/sdks/typescript/tests/coop.test.mjs
+++ b/sdks/typescript/tests/coop.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
+import { createHash, webcrypto } from "node:crypto";
 import test from "node:test";
 
 import {
@@ -707,6 +707,56 @@ test("attestation downloads preserve exact binary order and expose validated met
     assert.equal(call.init.redirect, "error");
     assert.equal(call.init.headers.Authorization, "Bearer tenant-secret");
     assert.equal(call.url.toString().includes("tenant-secret"), false);
+  }
+});
+
+test("artifact digests use Node Web Crypto when the global is unavailable", async () => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+  const bytes = Uint8Array.from([1, 2, 3, 4]);
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  try {
+    Object.defineProperty(globalThis, "crypto", { configurable: true, value: undefined });
+    const client = new Rookhold("https://example.test", "secret", {
+      fetch: async () => binaryResponse(bytes, "application/octet-stream", {
+        "x-content-sha256": digest,
+      }),
+    });
+    const artifact = await client.downloadAttestation("job");
+    assert.equal(artifact.sha256, digest);
+  } finally {
+    if (original) Object.defineProperty(globalThis, "crypto", original);
+    else delete globalThis.crypto;
+  }
+});
+
+test("artifact digests prefer browser-global Web Crypto", async () => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+  const bytes = Uint8Array.from([5, 6, 7, 8]);
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  let calls = 0;
+  try {
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: {
+        subtle: {
+          digest: async (...args) => {
+            calls += 1;
+            return webcrypto.subtle.digest(...args);
+          },
+        },
+      },
+    });
+    const client = new Rookhold("https://example.test", "secret", {
+      fetch: async () => binaryResponse(bytes, "application/octet-stream", {
+        "x-content-sha256": digest,
+      }),
+    });
+    const artifact = await client.downloadAttestation("job");
+    assert.equal(artifact.sha256, digest);
+    assert.equal(calls, 1);
+  } finally {
+    if (original) Object.defineProperty(globalThis, "crypto", original);
+    else delete globalThis.crypto;
   }
 });
 


### PR DESCRIPTION
## Contribution tier

Tier C — release workflow, public acquisition paths, security-posture documentation, and compatibility gates.

## Declared scope

Make v0.8.0 the complete public developer path: centralize release URLs, distinguish app/client/SDK roles, route first-time users to the complete app, publish exact release-package installation commands, correct local-versus-gVisor demonstrations, and execute the local documentation snapshot on every supported operating system.

## Root invariant

No public surface may imply that the zero-configuration local path contains untrusted code. Local execution must report host networking and isolation none; gVisor claims require a separately configured Linux service that satisfies the requested class. Named registry installs remain explicitly deferred; later registry publication must reuse immutable release bytes through the protected follow-up workflow.

## Reproduction and RED evidence

RED: the public site and README routed first-time users to v0.7.1's existing-server client, advertised unavailable registry commands, and showed a zero-configuration command beside disabled networking and gVisor output. npm and PyPI still return 404 for `rookhold`. The real local binary snapshot now fails any false isolation, networking, identity, or receipt-path claim.

## Changes

- centralize the exact eleven-asset v0.8.0 release contract in `release.json`
- distinguish complete app bundles, standalone clients, MCP, and SDK packages
- show truthful local host networking and no-isolation output
- explicitly request `allow_network: false` for unified CLI submissions
- execute the local documentation snapshot on Windows, macOS, and Linux
- stage and reconcile the GitHub draft, clean-install exact SDK artifacts, and publish GitHub last
- install Python and TypeScript directly from immutable GitHub release assets while named registries are deferred
- add protected `publish-packages.yml` follow-up publishing without rebuilding release bytes
- reconcile registry retries by exact digest, reject redirects and duplicate JSON members, and fail on mismatches
- enforce candidate-to-current documentation wording in both directions

## Adversarial coverage

- [x] local verifier independently rejects non-host networking and false gVisor claims
- [x] verifier rejects missing, malformed, stale, traversing, out-of-tree, or symlinked receipt evidence
- [x] release metadata enumerates exactly eleven public assets
- [x] draft publication cannot occur before exact wheel and npm-tarball clean installs succeed
- [x] deferred registry publication verifies checksums, provenance, exact file sets, and remote digests
- [x] registry reconciliation refuses redirects, duplicate JSON members, and byte mismatches
- [x] current-release state rejects lingering candidate and pre-publication phrases

## Validation

- Head: 948a80c4542ba9264975aae1cad973a4db632a6f
- Checks: cargo fmt; Clippy with warnings denied; complete locked Rust workspace tests; 89 Python SDK/CLI/MCP tests; 54 TypeScript tests and typecheck; 41 release/support-script tests; Python wheel/sdist and npm pack smoke; release-surface validation; desktop/mobile browser verification; exact-head compatibility run 33578930555 across Python 3.9–3.14, Node 18/20/22/24, Windows, macOS, Linux, recipes/MCP, and Chrome.

## Non-goals and remaining work

This PR does not itself create the tag. Named PyPI and npm installs remain deferred while maintainer accounts are activated. v0.8.0 instead ships the exact wheel and npm tarball as verified GitHub release assets. The protected follow-up workflow publishes those immutable bytes later without rebuilding them.

## Safety and compatibility

Existing APIs, database schemas, evidence formats, internal `coop-*` crate identities, compatibility imports, environment aliases, and v0.7 artifacts remain unchanged. Release publishing retains environment approval, exact asset reconciliation, SBOM, provenance, immutable releases, clean artifact installation, and fail-closed remote digest checks.

## Completion state

- Implementation: complete
- Validation: complete; hosted CI and exact-head compatibility run 33578930555 are green
- Review: complete; all CodeRabbit threads are resolved
- Integration: ready for GitHub v0.8.0; named PyPI/npm installs are explicitly deferred

