### PR TITLE
docs: mark v0.8.0 current

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ verifiable receipt of what happened.
 [![Release](https://img.shields.io/github/v/release/sambai-dev/rookhold)](https://github.com/sambai-dev/rookhold/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Release candidate:** v0.8.0. See [all releases](https://github.com/sambai-dev/rookhold/releases).
-The download and registry links below become available when the release
-workflow publishes. Until then, use the [source build](#build-from-source).
+**Current release:** [v0.8.0](https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0).
+Downloads and direct SDK packages are available now. Named PyPI and npm installs
+remain deferred while maintainer registry accounts are activated.
 
 Rookhold is for applications, agents, evaluators, graders, and automations that
 receive a short piece of code but should not hand it the host machine. It is a
@@ -18,7 +18,7 @@ or general-purpose cloud sandbox.
 
 ## Try Rookhold locally
 
-After v0.8.0 publishes, choose the complete **Rookhold app** bundle. It contains
+Choose the complete **Rookhold app** bundle. It contains
 the unified `rookhold` command, remote client, MCP adapter, offline verifier,
 and setup templates.
 
@@ -80,7 +80,7 @@ untrusted workloads.
 
 ### Python
 
-After v0.8.0 publishes:
+Install the v0.8.0 release wheel:
 
 ```bash
 pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl
@@ -95,7 +95,7 @@ print(result.stdout)
 
 ### TypeScript
 
-After v0.8.0 publishes:
+Install the v0.8.0 release tarball:
 
 ```bash
 npm install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz
@@ -120,7 +120,7 @@ console.log(result.stdout);
 
 ## Connect to an existing Rookhold server
 
-After v0.8.0 publishes, the **Rookhold client** is the smallest download for a
+The **Rookhold client** is the smallest download for a
 person or MCP host that already has a Rookhold endpoint. It does not include
 the local service.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ Choose the Rookhold surface that matches what you are doing.
 
 ## Rookhold app
 
-After v0.8.0 publishes, use the complete app when you want `rookhold run`, a
+Use the complete app when you want `rookhold run`, a
 local trusted-code service, the persistent server, setup commands, remote
 client, MCP, and the verifier.
 
@@ -27,7 +27,7 @@ python -m pip install ./sdks/python
 npm install ./sdks/typescript
 ```
 
-After publication, install the exact GitHub release packages:
+Install the exact GitHub release packages:
 
 ```bash
 pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl
@@ -41,7 +41,7 @@ execution boundary.
 
 ## Standalone client
 
-After v0.8.0 publishes, use the standalone `rookhold-cli` download when a person
+Use the standalone `rookhold-cli` download when a person
 or MCP host already has a Rookhold endpoint and does not need the service or
 local-run workflow.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-After v0.8.0 publishes, download the complete Rookhold app for your computer:
+Download the current complete Rookhold app for your computer:
 
 | Computer | App bundle |
 |---|---|
@@ -8,7 +8,7 @@ After v0.8.0 publishes, download the complete Rookhold app for your computer:
 | Mac with Apple Silicon | [Download for Mac](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz) |
 | Linux x86_64 | [Download for Linux](https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-unknown-linux-musl.tar.gz) |
 
-Before publication, run the same candidate from a checkout:
+Contributors can instead run the same version from a checkout:
 
 ```bash
 git clone https://github.com/sambai-dev/rookhold.git
@@ -17,7 +17,7 @@ cargo build --locked -p coop-server --bin rookhold
 target/debug/rookhold run python 'print(6 * 7)'
 ```
 
-## After v0.8.0 publishes
+## Run the release
 
 Extract it, then run one job. On Windows:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,8 @@ hero:
 ---
 
 <section class="release-candidate-note" aria-label="v0.8.0 publication status">
-  <strong>v0.8.0 release candidate</strong>
-  <span>Downloads and registry commands activate after the release workflow publishes. Until then, <a href="https://github.com/sambai-dev/rookhold#build-from-source">build from main</a>.</span>
+  <strong>v0.8.0 is current</strong>
+  <span>App, CLI, Python wheel, and TypeScript tarball downloads are live. Named registry installs remain deferred.</span>
 </section>
 
 <section class="home-use-cases" aria-label="Common Rookhold use cases">
@@ -52,7 +52,7 @@ hero:
 <section id="try" class="download-section" aria-labelledby="try-heading">
   <div class="section-heading">
     <h2 id="try-heading">Try the Rookhold app.</h2>
-    <p>After v0.8.0 publishes, the complete bundle contains the unified app, local service, remote client, MCP adapter, verifier, and setup templates.</p>
+    <p>The complete bundle contains the unified app, local service, remote client, MCP adapter, verifier, and setup templates.</p>
   </div>
   <div class="download-grid">
     <a class="download-option" aria-label="Download the Rookhold app for 64-bit Windows" href="https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip"><strong>Windows</strong></a>
@@ -65,7 +65,7 @@ hero:
 <section id="sdk" class="sdk-section" aria-labelledby="sdk-heading">
   <div class="section-heading">
     <h2 id="sdk-heading">Add Rookhold to an application.</h2>
-    <p>After v0.8.0 publishes, install the SDKs from the registries. They submit jobs to an endpoint and do not create the guarded Linux boundary by themselves.</p>
+    <p>Install the exact v0.8.0 SDK release assets. They submit jobs to an endpoint and do not create the guarded Linux boundary by themselves.</p>
   </div>
   <div class="sdk-layout">
     <div class="install-command"><span>Python</span><code>pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl</code><a href="./use/python">Python guide →</a></div>
@@ -77,7 +77,7 @@ hero:
 <section class="client-section" aria-labelledby="client-heading">
   <div class="section-heading">
     <h2 id="client-heading">Already have a Rookhold server?</h2>
-    <p>After v0.8.0 publishes, the standalone client is the smaller human and MCP interface. It does not include the service or local-run workflow.</p>
+    <p>The standalone client is the smaller human and MCP interface. It does not include the service or local-run workflow.</p>
     <div class="home-demo-actions">
       <a class="home-text-link" href="./use/cli">Client guide <span aria-hidden="true">→</span></a>
       <a class="home-text-link" href="./use/mcp">MCP setup <span aria-hidden="true">→</span></a>

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -2,7 +2,7 @@
 
 Rookhold ships small reference clients under `sdks/`. They intentionally mirror the HTTP API and are suitable for embedding in agent tool loops. The OpenAPI document remains the canonical contract for generated clients.
 
-After v0.8.0 publishes, install the exact release assets:
+Install the exact v0.8.0 release assets:
 
 ```bash
 pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl
@@ -13,7 +13,7 @@ Named PyPI and npm installs are deferred while maintainer registry accounts are
 activated. A protected follow-up workflow will publish these same immutable
 v0.8.0 bytes through registry trusted publishing; it does not rebuild them.
 
-Before publication, install from the checkout with
+Contributors can install from a checkout with
 `python -m pip install ./sdks/python` or `npm install ./sdks/typescript`.
 
 Exact candidate release files:

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
   "current_version": "0.8.0",
-  "release_status": "candidate",
+  "release_status": "current",
   "release_url": "https://github.com/sambai-dev/rookhold/releases/tag/v0.8.0",
   "windows_app_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-x86_64-pc-windows-msvc.zip",
   "mac_app_url": "https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-aarch64-apple-darwin.tar.gz",

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -4,13 +4,13 @@ A typed synchronous client and stdio MCP adapter with no required dependencies.
 Install the optional stream extra for a native WebSocket; otherwise `stream()`
 transparently uses cursor replay.
 
-Before v0.8.0 publishes, install from the checkout:
+Contributors can install from a checkout:
 
 ```bash
 python -m pip install "./sdks/python[stream]"
 ```
 
-After publication, install the exact release wheel:
+Install the exact v0.8.0 release wheel:
 
 ```bash
 python -m pip install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0-py3-none-any.whl

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -9,7 +9,7 @@ permissive CORS headers; a cross-origin frontend needs an explicitly
 allowlisted reverse-proxy policy, and its bearer key will be available to that
 frontend's JavaScript.
 
-Before v0.8.0 publishes, build and pack the checkout:
+Contributors can build and pack the checkout:
 
 ```bash
 cd sdks/typescript
@@ -17,7 +17,7 @@ npm ci
 npm pack
 ```
 
-After publication, install the exact release tarball:
+Install the exact v0.8.0 release tarball:
 
 ```bash
 npm install https://github.com/sambai-dev/rookhold/releases/download/v0.8.0/rookhold-0.8.0.tgz


### PR DESCRIPTION
## Contribution tier

Tier A — post-release documentation state only.

## Declared scope

Mark the already-published immutable v0.8.0 release as current across README, website, quickstart, installation, and SDK entry points while retaining the explicit named-registry deferral.

## Changes

- switch `release.json` from `candidate` to `current`
- replace all candidate and pre-publication wording on consumer surfaces
- link the current v0.8.0 release and keep direct wheel/tarball installation commands executable
- preserve the note that named PyPI and npm installs remain deferred

## Validation

- `python scripts/check-release-surface.py`
- `python -m unittest discover -s scripts/tests -v` (41 passed)
- no candidate, after-publication, or until-then phrases remain on current consumer surfaces
- public v0.8.0 is latest, immutable, and has exactly eleven SHA-256-addressed assets
