### PR TITLE
style: remove projects heading divider

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -61,6 +61,7 @@ body { background: #fdfeff; }
 .VPHero .actions .action:nth-child(3) .VPButton:hover { background: #edf2ff !important; }
 
 .vp-doc div[class*=language-] { border-radius: 4px; }
+.projects-page .vp-doc h2 { border-top: 0; }
 .VPHome .VPContent { overflow: hidden; }
 .VPHome .vp-doc.container { max-width: none; padding: 0; }
 .VPHome section:not(.boundary-section):not(.final-cta) {

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,3 +1,7 @@
+---
+pageClass: projects-page
+---
+
 # Projects using Rookhold
 
 No project is listed without its maintainer's permission. If Rookhold is part


### PR DESCRIPTION
## Contribution tier

Tier A — page-scoped visual refinement.

## Declared scope

Remove the heavy horizontal divider above the secondary heading on the Projects using Rookhold page without changing borders elsewhere in the documentation.

## Changes

- add a page-specific `projects-page` class
- remove the VitePress `h2` top border only inside that page

## Validation

- Impeccable detector: no findings
- VitePress production build: passed
- rendered `/projects` page: meaningful content, no error overlay, page class present, computed heading `border-top-width` is `0px`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated project documentation pages to display level-two headings without a top border.
  * Applied page-specific styling to ensure the change affects only project pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->