### PR TITLE
revert: restore projects heading divider

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -61,7 +61,6 @@ body { background: #fdfeff; }
 .VPHero .actions .action:nth-child(3) .VPButton:hover { background: #edf2ff !important; }
 
 .vp-doc div[class*=language-] { border-radius: 4px; }
-.projects-page .vp-doc h2 { border-top: 0; }
 .VPHome .VPContent { overflow: hidden; }
 .VPHome .vp-doc.container { max-width: none; padding: 0; }
 .VPHome section:not(.boundary-section):not(.final-cta) {

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,7 +1,3 @@
----
-pageClass: projects-page
----
-
 # Projects using Rookhold
 
 No project is listed without its maintainer's permission. If Rookhold is part


### PR DESCRIPTION
## Contribution tier

Tier A — exact revert of the mistakenly targeted page style.

## Declared scope

Restore the Rookhold Projects page to its state before PR #45. The requested visual change belongs to another project.

## Changes

- remove the temporary `projects-page` frontmatter
- remove the page-scoped heading-border override

## Validation

- exact revert of merge commit `08aad5d44e705d83238c051203d5a73cab2d9782`
- no v0.8 release, SDK, runtime, or unrelated documentation changes
