### PR TITLE
growth: add opt-in adoption feedback loop

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
 blank_issues_enabled: false
 contact_links:
+  - name: First-run feedback thread
+    url: https://github.com/sambai-dev/rookhold/discussions/57
+    about: Share a short success, blocker, or unclear first-run step without opening an issue.
+  - name: Ask a question
+    url: https://github.com/sambai-dev/rookhold/discussions/categories/q-a
+    about: Get help using or deploying Rookhold.
+  - name: Show what you built
+    url: https://github.com/sambai-dev/rookhold/discussions/categories/show-and-tell
+    about: Share a public application, agent, evaluator, or automation using Rookhold.
   - name: Security vulnerability
     url: https://github.com/sambai-dev/rookhold/security/policy
     about: Report vulnerabilities privately using the security policy.

--- a/.github/ISSUE_TEMPLATE/first-run-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/first-run-feedback.yml
@@ -1,0 +1,89 @@
+name: First-run feedback
+description: Share a 60-second report about your first Rookhold result or blocker
+title: "feedback: "
+labels:
+  - first-run-feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for trying Rookhold. Short, honest reports are more useful than polished reviews.
+        Do not include API keys, private code, tenant identifiers, or sensitive paths.
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: Where did you get to?
+      options:
+        - Completed a trusted local run
+        - Connected an MCP host
+        - Connected to a guarded Rookhold service
+        - Blocked before the first result
+    validations:
+      required: true
+  - type: dropdown
+    id: install_path
+    attributes:
+      label: How did you install or run Rookhold?
+      options:
+        - Windows app bundle
+        - macOS app bundle
+        - Linux app bundle
+        - Standalone CLI
+        - Python release wheel
+        - TypeScript release tarball
+        - Source checkout
+    validations:
+      required: true
+  - type: dropdown
+    id: time_to_result
+    attributes:
+      label: Time to the first successful result
+      options:
+        - Under 2 minutes
+        - 2–5 minutes
+        - 5–15 minutes
+        - More than 15 minutes
+        - Did not complete
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Operating system and architecture
+      placeholder: Windows 11 x86_64, macOS Apple Silicon, or Ubuntu 24.04 x86_64
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Rookhold version
+      value: v0.8.0
+    validations:
+      required: true
+  - type: textarea
+    id: first_unclear_point
+    attributes:
+      label: What was the first unclear or frustrating point?
+      description: Quote the instruction or describe the exact step where you hesitated or stopped.
+      placeholder: I expected… but the first confusing point was…
+    validations:
+      required: true
+  - type: textarea
+    id: intended_use
+    attributes:
+      label: What would you use Rookhold for?
+      placeholder: Generated scripts, grading, an MCP host, an application feature, or something else
+  - type: checkboxes
+    id: public_project
+    attributes:
+      label: Optional public project listing
+      options:
+        - label: You may quote this report and list my linked public project on the Rookhold site.
+          required: false
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety check
+      options:
+        - label: I removed credentials, private code, tenant identifiers, and sensitive paths.
+          required: true

--- a/.github/workflows/adoption-pulse.yml
+++ b/.github/workflows/adoption-pulse.yml
@@ -1,0 +1,66 @@
+name: adoption pulse
+
+on:
+  schedule:
+    - cron: "17 20 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    name: update maintainer adoption pulse
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out reporting code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Build the current adoption report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ROOKHOLD_REPOSITORY: ${{ github.repository }}
+        run: >-
+          python3 scripts/adoption-pulse.py
+          --repository "$ROOKHOLD_REPOSITORY"
+          --output adoption-pulse.md
+      - name: Update one durable public issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ROOKHOLD_REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          title='[Maintainer] Adoption pulse'
+          gh label create adoption-pulse \
+            --repo "$ROOKHOLD_REPOSITORY" \
+            --description 'Automatically refreshed public adoption signals' \
+            --color 1d76db \
+            --force
+          mapfile -t matches < <(gh issue list \
+            --repo "$ROOKHOLD_REPOSITORY" \
+            --state open \
+            --label adoption-pulse \
+            --limit 20 \
+            --json number,title \
+            --jq ".[] | select(.title == \"$title\") | .number")
+          if [ "${#matches[@]}" -gt 1 ]; then
+            echo 'More than one open adoption pulse issue exists; refusing an ambiguous update.' >&2
+            exit 1
+          fi
+          if [ "${#matches[@]}" -eq 0 ]; then
+            gh issue create \
+              --repo "$ROOKHOLD_REPOSITORY" \
+              --title "$title" \
+              --label adoption-pulse \
+              --body-file adoption-pulse.md
+          else
+            gh issue edit "${matches[0]}" \
+              --repo "$ROOKHOLD_REPOSITORY" \
+              --body-file adoption-pulse.md
+          fi

--- a/.github/workflows/adoption-pulse.yml
+++ b/.github/workflows/adoption-pulse.yml
@@ -6,7 +6,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: read # permit checkout and public repository API reads
+
+concurrency:
+  group: adoption-pulse-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   update:
@@ -14,8 +18,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
-      contents: read
-      issues: write
+      contents: read # permit checkout and public repository API reads
+      issues: write # update the single public adoption pulse issue
     steps:
       - name: Check out reporting code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,13 +46,13 @@ jobs:
             --description 'Automatically refreshed public adoption signals' \
             --color 1d76db \
             --force
-          mapfile -t matches < <(gh issue list \
-            --repo "$ROOKHOLD_REPOSITORY" \
-            --state open \
-            --label adoption-pulse \
-            --limit 20 \
-            --json number,title \
-            --jq ".[] | select(.title == \"$title\") | .number")
+          lookup_file="$(mktemp)"
+          trap 'rm -f "$lookup_file"' EXIT
+          gh api --paginate \
+            "repos/${ROOKHOLD_REPOSITORY}/issues?state=open&labels=adoption-pulse&per_page=100" \
+            --jq '.[] | select(.pull_request == null) | select(.title == "[Maintainer] Adoption pulse") | .number' \
+            > "$lookup_file"
+          mapfile -t matches < "$lookup_file"
           if [ "${#matches[@]}" -gt 1 ]; then
             echo 'More than one open adoption pulse issue exists; refusing an ambiguous update.' >&2
             exit 1

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ The CLI explicitly requests `allow_network: false`; the guarded service must
 also report disabled networking and the required isolation class.
 
 [Read the quickstart](https://rookhold.pages.dev/getting-started/quickstart) ·
-[Deploy the secure boundary](https://rookhold.pages.dev/getting-started/first-secure-deployment)
+[Deploy the secure boundary](https://rookhold.pages.dev/getting-started/first-secure-deployment) ·
+[Share 60-second feedback](https://github.com/sambai-dev/rookhold/issues/new?template=first-run-feedback.yml)
 
 ## Add Rookhold to an application
 
@@ -210,6 +211,7 @@ untrusted jobs.
 - [Receipts and verification](https://rookhold.pages.dev/understand/receipts)
 - [Deployment and operations](https://rookhold.pages.dev/deployment)
 - [Compatibility](https://rookhold.pages.dev/compatibility)
+- [Feedback](https://rookhold.pages.dev/feedback)
 - [Release process](docs/releasing.md)
 
 ## Contributing

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -90,6 +90,7 @@ export default defineConfig({
             { text: "Contribution tiers", link: "/contributing" },
             { text: "Runtime packs", link: "/runtime-packs" },
             { text: "Integrations", link: "/integrations" },
+            { text: "Feedback", link: "/feedback" },
           ],
         },
       ],

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -1,0 +1,32 @@
+# Feedback
+
+Rookhold does not send hidden product telemetry. Adoption and usability are
+measured through opt-in reports and public repository signals.
+
+## Share a first run
+
+Run the [two-minute quickstart](getting-started/quickstart.md), including one
+successful `print(6 * 7)` job and one deliberate two-second timeout. Then choose
+one path:
+
+- [Submit the 60-second first-run form](https://github.com/sambai-dev/rookhold/issues/new?template=first-run-feedback.yml)
+- [Reply in the first-run discussion](https://github.com/sambai-dev/rookhold/discussions/57)
+- [Ask for help](https://github.com/sambai-dev/rookhold/discussions/categories/q-a)
+- [Show what you built](https://github.com/sambai-dev/rookhold/discussions/categories/show-and-tell)
+
+The most useful report includes your operating system, installation path, time
+to first result, and the first instruction or behavior that felt unclear. Never
+post API keys, private code, tenant identifiers, or sensitive paths.
+
+## What maintainers watch
+
+The weekly adoption pulse prioritizes:
+
+1. completed first-run reports;
+2. public forks or integrations;
+3. outside contributors; and
+4. repeated friction worth fixing.
+
+Stars, page views, and release downloads provide context, but they do not prove
+that someone successfully used Rookhold. CI-inflated clone traffic is explicitly
+excluded from adoption conclusions.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -69,3 +69,6 @@ display text.
 
 Next: [install an SDK](installation.md#sdk) or
 [deploy the secure Linux boundary](first-secure-deployment.md).
+
+Finished or blocked? [Share a 60-second first-run report](../feedback.md). The
+first unclear step is more valuable than a general review.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -50,6 +50,15 @@ This local mode is convenient, not contained. It has host networking and the
 service account's authority. Use it only for code you trust.
 :::
 
+Confirm that the local wall-clock deadline works with a deliberate two-second
+timeout:
+
+```bash
+rookhold run python 'while True: pass' --wall-seconds 2
+```
+
+The result should report `status: timed_out` after approximately two seconds.
+
 For untrusted code, connect the same app to a guarded Linux service and require
 its observed isolation class:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,10 @@ hero:
   <div class="home-demo-copy">
     <h2 id="demo-heading">One command to a real result.</h2>
     <p>With no endpoint configured, the Rookhold app starts a temporary loopback service, runs trusted code, saves the receipt, and removes the service state. It reports the weak local posture plainly.</p>
-    <a class="home-text-link" href="./getting-started/quickstart">Open the two-minute quickstart <span aria-hidden="true">→</span></a>
+    <div class="home-demo-actions">
+      <a class="home-text-link" href="./getting-started/quickstart">Open the two-minute quickstart <span aria-hidden="true">→</span></a>
+      <a class="home-text-link" href="./feedback">Share first-run feedback <span aria-hidden="true">→</span></a>
+    </div>
   </div>
   <div class="terminal-stage" role="img" aria-label="Local trusted-code run reporting host networking and no isolation">
     <div class="terminal-head"><span>rookhold app</span><span class="local-caution">local · trusted code only</span></div>

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -3,14 +3,15 @@
 Rookhold runs short Python, Node, and Bash jobs with hard limits, live output,
 and receipts. It is not a persistent development workspace or remote computer.
 
-Start: /rookhold/getting-started/quickstart
-CLI: /rookhold/use/cli
-Python: /rookhold/use/python
-TypeScript: /rookhold/use/typescript
-MCP: /rookhold/use/mcp
-Limits: /rookhold/understand/limits
-Receipts: /rookhold/understand/receipts
-Isolation: /rookhold/understand/isolation
-Deployment: /rookhold/deployment
-Security boundary: /rookhold/security-boundary
-API: /rookhold/api
+Start: https://rookhold.pages.dev/getting-started/quickstart
+Feedback: https://rookhold.pages.dev/feedback
+CLI: https://rookhold.pages.dev/use/cli
+Python: https://rookhold.pages.dev/use/python
+TypeScript: https://rookhold.pages.dev/use/typescript
+MCP: https://rookhold.pages.dev/use/mcp
+Limits: https://rookhold.pages.dev/understand/limits
+Receipts: https://rookhold.pages.dev/understand/receipts
+Isolation: https://rookhold.pages.dev/understand/isolation
+Deployment: https://rookhold.pages.dev/deployment
+Security boundary: https://rookhold.pages.dev/security-boundary
+API: https://rookhold.pages.dev/api

--- a/scripts/adoption-pulse.py
+++ b/scripts/adoption-pulse.py
@@ -101,7 +101,13 @@ def build_snapshot(client: GitHub, repository: str) -> dict[str, Any]:
         for row in contributors
         if is_external(row.get("login"), owner)
     }
-    feedback = [row for row in issues if "first-run-feedback" in label_names(row)]
+    feedback = [
+        row
+        for row in issues
+        if "first-run-feedback" in label_names(row)
+        and isinstance(row.get("user"), dict)
+        and is_external(row["user"].get("login"), owner)
+    ]
     latest = next(
         (release for release in releases if not release.get("draft") and not release.get("prerelease")),
         None,

--- a/scripts/adoption-pulse.py
+++ b/scripts/adoption-pulse.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Build a conservative public adoption pulse from GitHub repository signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def is_external(login: object, owner: str) -> bool:
+    if not isinstance(login, str) or not login:
+        return False
+    folded = login.casefold()
+    return folded != owner.casefold() and not folded.endswith("[bot]") and folded != "app/dependabot"
+
+
+class GitHub:
+    def get(self, path: str) -> Any:
+        result = subprocess.run(
+            ["gh", "api", path, "-H", "X-GitHub-Api-Version: 2022-11-28"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        require(result.returncode == 0, f"GitHub API request failed for {path}")
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"GitHub API returned malformed JSON for {path}") from error
+
+    def all(self, path: str) -> list[dict[str, Any]]:
+        separator = "&" if "?" in path else "?"
+        rows: list[dict[str, Any]] = []
+        for page in range(1, 11):
+            value = self.get(f"{path}{separator}per_page=100&page={page}")
+            require(isinstance(value, list), f"GitHub API returned a non-list for {path}")
+            require(all(isinstance(row, dict) for row in value), f"GitHub API returned malformed rows for {path}")
+            rows.extend(value)
+            if len(value) < 100:
+                return rows
+        raise ValueError(f"GitHub API pagination exceeded 1,000 rows for {path}")
+
+
+def label_names(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {
+        label["name"]
+        for label in labels
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    }
+
+
+def build_snapshot(client: GitHub, repository: str) -> dict[str, Any]:
+    require(repository.count("/") == 1, "repository must use owner/name")
+    owner, name = repository.split("/", 1)
+    encoded = f"{quote(owner, safe='')}/{quote(name, safe='')}"
+    repo = client.get(f"/repos/{encoded}")
+    try:
+        views = client.get(f"/repos/{encoded}/traffic/views")
+        clones = client.get(f"/repos/{encoded}/traffic/clones")
+    except ValueError:
+        views = {}
+        clones = {}
+    issues = [
+        row
+        for row in client.all(f"/repos/{encoded}/issues?state=all")
+        if "pull_request" not in row
+    ]
+    pulls = client.all(f"/repos/{encoded}/pulls?state=all")
+    contributors = client.all(f"/repos/{encoded}/contributors?anon=1")
+    releases = client.all(f"/repos/{encoded}/releases")
+
+    external_issue_authors = {
+        row.get("user", {}).get("login")
+        for row in issues
+        if isinstance(row.get("user"), dict)
+        and is_external(row["user"].get("login"), owner)
+    }
+    external_pr_authors = {
+        row.get("user", {}).get("login")
+        for row in pulls
+        if isinstance(row.get("user"), dict)
+        and is_external(row["user"].get("login"), owner)
+    }
+    external_contributors = {
+        row.get("login")
+        for row in contributors
+        if is_external(row.get("login"), owner)
+    }
+    feedback = [row for row in issues if "first-run-feedback" in label_names(row)]
+    latest = next(
+        (release for release in releases if not release.get("draft") and not release.get("prerelease")),
+        None,
+    )
+    latest_downloads = 0
+    latest_tag = "none"
+    if isinstance(latest, dict):
+        latest_tag = str(latest.get("tag_name") or "unknown")
+        assets = latest.get("assets")
+        if isinstance(assets, list):
+            latest_downloads = sum(
+                int(asset.get("download_count", 0))
+                for asset in assets
+                if isinstance(asset, dict)
+            )
+    return {
+        "repository": repository,
+        "stars": int(repo.get("stargazers_count", 0)),
+        "forks": int(repo.get("forks_count", 0)),
+        "watchers": int(repo.get("subscribers_count", 0)),
+        "unique_views": views.get("uniques") if isinstance(views.get("uniques"), int) else None,
+        "unique_cloners": clones.get("uniques") if isinstance(clones.get("uniques"), int) else None,
+        "first_run_feedback": len(feedback),
+        "external_issue_authors": len(external_issue_authors),
+        "external_pr_authors": len(external_pr_authors),
+        "external_contributors": len(external_contributors | external_pr_authors),
+        "latest_tag": latest_tag,
+        "latest_downloads": latest_downloads,
+    }
+
+
+def progress(value: int, target: int) -> str:
+    return "met" if value >= target else f"{target - value} to go"
+
+
+def display_optional(value: object) -> str:
+    return str(value) if isinstance(value, int) else "Unavailable to workflow token"
+
+
+def build_report(snapshot: dict[str, Any], captured_at: datetime) -> str:
+    first_runs = int(snapshot["first_run_feedback"])
+    forks = int(snapshot["forks"])
+    contributors = int(snapshot["external_contributors"])
+    next_action = (
+        "Ask five outside developers to complete the two-minute quickstart and submit the first-run form."
+        if first_runs < 5
+        else "Turn the most repeated first-run friction into one bounded improvement or starter contribution."
+    )
+    return f"""<!-- rookhold-adoption-pulse -->
+# Adoption pulse
+
+Updated {captured_at.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} from GitHub's repository APIs.
+
+## Outcomes
+
+| Signal | Current | Initial target | Status |
+|---|---:|---:|---|
+| First-run feedback reports | {first_runs} | 5 | {progress(first_runs, 5)} |
+| Public forks | {forks} | 1 | {progress(forks, 1)} |
+| External contributors | {contributors} | 1 | {progress(contributors, 1)} |
+
+## Context
+
+| Signal | Current |
+|---|---:|
+| Stars | {int(snapshot['stars'])} |
+| Unique repository visitors, rolling 14 days | {display_optional(snapshot['unique_views'])} |
+| {snapshot['latest_tag']} release asset downloads | {int(snapshot['latest_downloads'])} |
+| External issue authors | {int(snapshot['external_issue_authors'])} |
+| External pull-request authors | {int(snapshot['external_pr_authors'])} |
+
+## Next action
+
+{next_action}
+
+## Interpretation guardrails
+
+- Stars, views, and downloads are attention signals, not proof of a successful run.
+- Unique cloners ({display_optional(snapshot['unique_cloners'])}) are not an adoption KPI because the CI matrix creates many automated checkouts.
+- Rookhold sends no hidden product telemetry; this pulse uses GitHub aggregates and opt-in public feedback.
+"""
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    root.add_argument("--repository", required=True)
+    root.add_argument("--output", type=Path, required=True)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        snapshot = build_snapshot(GitHub(), args.repository)
+        args.output.write_text(
+            build_report(snapshot, datetime.now(timezone.utc)),
+            encoding="utf-8",
+        )
+    except (OSError, TypeError, ValueError) as error:
+        print(f"adoption pulse failed: {error}", file=sys.stderr)
+        return 1
+    print(f"wrote conservative adoption pulse to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -38,6 +38,148 @@ def require(condition: bool, message: str) -> None:
         raise AssertionError(message)
 
 
+def yaml_scalar(raw: str) -> str:
+    value = raw.split(" #", 1)[0].strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def yaml_block(source: str, key: str, indent: int) -> list[str]:
+    lines = source.splitlines()
+    header = " " * indent + key + ":"
+    matches = [index for index, line in enumerate(lines) if line == header]
+    require(len(matches) == 1, f"YAML must contain exactly one {key} block at indent {indent}")
+    block: list[str] = []
+    for line in lines[matches[0] + 1 :]:
+        if line.strip() and not line.lstrip().startswith("#"):
+            current_indent = len(line) - len(line.lstrip(" "))
+            if current_indent <= indent:
+                break
+        block.append(line)
+    return block
+
+
+def yaml_mapping(lines: list[str], indent: int, context: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent != indent or line[indent:].startswith("- "):
+            continue
+        match = re.fullmatch(r"([A-Za-z0-9_-]+):(?:\s*(.*))?", line[indent:])
+        require(match is not None, f"malformed YAML mapping entry in {context}: {line!r}")
+        key = match.group(1)
+        require(key not in values, f"duplicate YAML key in {context}: {key}")
+        values[key] = yaml_scalar(match.group(2) or "")
+    return values
+
+
+def yaml_sequence_scalars(lines: list[str], indent: int, context: str) -> list[str]:
+    values: list[str] = []
+    for line in lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent == indent:
+            require(line[indent:].startswith("- "), f"malformed YAML sequence in {context}")
+            values.append(yaml_scalar(line[indent + 2 :]))
+    return values
+
+
+def yaml_sequence_mappings(
+    source: str, key: str, header_indent: int, item_indent: int
+) -> list[tuple[dict[str, str], list[str]]]:
+    block = yaml_block(source, key, header_indent)
+    starts = [
+        index
+        for index, line in enumerate(block)
+        if line.startswith(" " * item_indent + "- ")
+        and len(line) - len(line.lstrip(" ")) == item_indent
+    ]
+    require(bool(starts), f"YAML sequence {key} contains no mappings")
+    items: list[tuple[dict[str, str], list[str]]] = []
+    for position, start in enumerate(starts):
+        end = starts[position + 1] if position + 1 < len(starts) else len(block)
+        lines = block[start:end]
+        first = re.fullmatch(r"\s*-\s+([A-Za-z0-9_-]+):(?:\s*(.*))?", lines[0])
+        require(first is not None, f"malformed YAML mapping in {key}")
+        values = {first.group(1): yaml_scalar(first.group(2) or "")}
+        nested = yaml_mapping(lines[1:], item_indent + 2, f"{key} item")
+        require(not set(values).intersection(nested), f"duplicate YAML key in {key} item")
+        values.update(nested)
+        items.append((values, lines))
+    return items
+
+
+def validate_feedback_form_contract(source: str) -> None:
+    require("\t" not in source, "feedback form YAML contains tabs")
+    top = yaml_mapping(source.splitlines(), 0, "feedback form")
+    require(top.get("name") == "First-run feedback", "feedback form name differs")
+    require(bool(top.get("description")), "feedback form description is missing")
+    labels = yaml_sequence_scalars(yaml_block(source, "labels", 0), 2, "feedback labels")
+    require(labels == ["first-run-feedback"], "feedback form label contract differs")
+    items = yaml_sequence_mappings(source, "body", 0, 2)
+    identified = [values["id"] for values, _ in items if values.get("id")]
+    require(len(identified) == len(set(identified)), "feedback form IDs are duplicated")
+    by_id = {
+        values["id"]: (values, lines)
+        for values, lines in items
+        if values.get("id")
+    }
+    for required_id in ["time_to_result", "first_unclear_point", "safety"]:
+        require(required_id in by_id, f"feedback form omits exact field: {required_id}")
+    safety_lines = by_id["safety"][1]
+    require(
+        any(
+            line.strip()
+            == "- label: I removed credentials, private code, tenant identifiers, and sensitive paths."
+            for line in safety_lines
+        ),
+        "feedback safety acknowledgement is missing from the safety field",
+    )
+
+
+def validate_adoption_workflow_contract(source: str) -> None:
+    require("\t" not in source, "adoption workflow YAML contains tabs")
+    yaml_mapping(source.splitlines(), 0, "adoption workflow")
+    schedule = yaml_block(source, "schedule", 2)
+    require(
+        yaml_sequence_scalars(schedule, 4, "adoption schedule") == ['cron: "17 20 * * 0"'],
+        "adoption workflow schedule differs",
+    )
+    concurrency = yaml_mapping(yaml_block(source, "concurrency", 0), 2, "adoption concurrency")
+    require(
+        concurrency
+        == {
+            "group": "adoption-pulse-${{ github.repository }}",
+            "cancel-in-progress": "false",
+        },
+        "adoption workflow concurrency contract differs",
+    )
+    top_permissions = yaml_mapping(
+        yaml_block(source, "permissions", 0), 2, "top-level adoption permissions"
+    )
+    require(top_permissions == {"contents": "read"}, "top-level adoption permissions differ")
+    update_lines = yaml_block(source, "update", 2)
+    update_source = "\n".join(update_lines)
+    job_permissions = yaml_mapping(
+        yaml_block(update_source, "permissions", 4), 6, "adoption job permissions"
+    )
+    require(
+        job_permissions == {"contents": "read", "issues": "write"},
+        "adoption job permissions are not exactly contents:read and issues:write",
+    )
+    for contract in [
+        "scripts/adoption-pulse.py",
+        "--output adoption-pulse.md",
+        "gh api --paginate",
+        "More than one open adoption pulse issue exists",
+    ]:
+        require(contract in update_source, f"adoption update job omits: {contract}")
+
+
 def check_release_status_language(
     release_status: str, version: str, surface_sources: dict[str, str]
 ) -> None:
@@ -1087,27 +1229,12 @@ def check_contribution_contract() -> None:
     ]:
         require(contract in ci, f"CI completion-evidence contract missing: {contract}")
 
-    feedback_form = read(".github/ISSUE_TEMPLATE/first-run-feedback.yml")
-    for contract in [
-        "first-run-feedback",
-        "time_to_result",
-        "first_unclear_point",
-        "I removed credentials, private code, tenant identifiers, and sensitive paths.",
-    ]:
-        require(contract in feedback_form, f"first-run feedback form missing: {contract}")
+    validate_feedback_form_contract(read(".github/ISSUE_TEMPLATE/first-run-feedback.yml"))
     feedback_docs = read("docs/feedback.md")
     require("does not send hidden product telemetry" in feedback_docs, "feedback docs omit telemetry posture")
     require("discussions/57" in feedback_docs, "feedback docs omit the durable first-run thread")
 
-    adoption_workflow = read(".github/workflows/adoption-pulse.yml")
-    for contract in [
-        'cron: "17 20 * * 0"',
-        "issues: write",
-        "scripts/adoption-pulse.py",
-        "adoption-pulse.md",
-        "More than one open adoption pulse issue exists",
-    ]:
-        require(contract in adoption_workflow, f"adoption pulse workflow missing: {contract}")
+    validate_adoption_workflow_contract(read(".github/workflows/adoption-pulse.yml"))
 
 
 def check_hostile_count() -> int:

--- a/scripts/check-release-surface.py
+++ b/scripts/check-release-surface.py
@@ -1087,6 +1087,28 @@ def check_contribution_contract() -> None:
     ]:
         require(contract in ci, f"CI completion-evidence contract missing: {contract}")
 
+    feedback_form = read(".github/ISSUE_TEMPLATE/first-run-feedback.yml")
+    for contract in [
+        "first-run-feedback",
+        "time_to_result",
+        "first_unclear_point",
+        "I removed credentials, private code, tenant identifiers, and sensitive paths.",
+    ]:
+        require(contract in feedback_form, f"first-run feedback form missing: {contract}")
+    feedback_docs = read("docs/feedback.md")
+    require("does not send hidden product telemetry" in feedback_docs, "feedback docs omit telemetry posture")
+    require("discussions/57" in feedback_docs, "feedback docs omit the durable first-run thread")
+
+    adoption_workflow = read(".github/workflows/adoption-pulse.yml")
+    for contract in [
+        'cron: "17 20 * * 0"',
+        "issues: write",
+        "scripts/adoption-pulse.py",
+        "adoption-pulse.md",
+        "More than one open adoption pulse issue exists",
+    ]:
+        require(contract in adoption_workflow, f"adoption pulse workflow missing: {contract}")
+
 
 def check_hostile_count() -> int:
     source = read("crates/coop-server/tests/hostile.rs")

--- a/scripts/tests/test_adoption_contracts.py
+++ b/scripts/tests/test_adoption_contracts.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import runpy
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = runpy.run_path(str(ROOT / "scripts" / "check-release-surface.py"))
+VALIDATE_FORM = CHECKER["validate_feedback_form_contract"]
+VALIDATE_WORKFLOW = CHECKER["validate_adoption_workflow_contract"]
+
+
+class AdoptionContractTests(unittest.TestCase):
+    def test_current_form_and_workflow_pass_structural_validation(self) -> None:
+        VALIDATE_FORM(
+            (ROOT / ".github" / "ISSUE_TEMPLATE" / "first-run-feedback.yml").read_text(
+                encoding="utf-8"
+            )
+        )
+        VALIDATE_WORKFLOW(
+            (ROOT / ".github" / "workflows" / "adoption-pulse.yml").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def test_malformed_form_and_misplaced_field_fail_closed(self) -> None:
+        source = (
+            ROOT / ".github" / "ISSUE_TEMPLATE" / "first-run-feedback.yml"
+        ).read_text(encoding="utf-8")
+        with self.assertRaisesRegex(AssertionError, "name differs|malformed"):
+            VALIDATE_FORM(source.replace("name: First-run feedback", "name First-run feedback"))
+        with self.assertRaisesRegex(AssertionError, "omits exact field"):
+            VALIDATE_FORM(source.replace("    id: time_to_result", "      id: time_to_result"))
+
+    def test_comment_only_or_additional_permissions_fail_closed(self) -> None:
+        source = (ROOT / ".github" / "workflows" / "adoption-pulse.yml").read_text(
+            encoding="utf-8"
+        )
+        comment_only = source.replace(
+            "      issues: write # update the single public adoption pulse issue",
+            "      # issues: write",
+        )
+        with self.assertRaisesRegex(AssertionError, "permissions"):
+            VALIDATE_WORKFLOW(comment_only)
+        additional = source.replace(
+            "      issues: write # update the single public adoption pulse issue",
+            "      issues: write\n      pull-requests: write",
+        )
+        with self.assertRaisesRegex(AssertionError, "permissions"):
+            VALIDATE_WORKFLOW(additional)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_adoption_pulse.py
+++ b/scripts/tests/test_adoption_pulse.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import runpy
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = runpy.run_path(str(ROOT / "scripts" / "adoption-pulse.py"))
+
+
+class AdoptionPulseTests(unittest.TestCase):
+    def test_external_identity_filter_excludes_owner_and_bots(self) -> None:
+        is_external = MODULE["is_external"]
+        self.assertFalse(is_external("sambai-dev", "sambai-dev"))
+        self.assertFalse(is_external("dependabot[bot]", "sambai-dev"))
+        self.assertFalse(is_external("app/dependabot", "sambai-dev"))
+        self.assertTrue(is_external("outside-user", "sambai-dev"))
+
+    def test_report_prioritizes_first_runs_and_qualifies_clone_traffic(self) -> None:
+        report = MODULE["build_report"](
+            {
+                "repository": "sambai-dev/rookhold",
+                "stars": 11,
+                "forks": 0,
+                "watchers": 0,
+                "unique_views": 19,
+                "unique_cloners": 210,
+                "first_run_feedback": 0,
+                "external_issue_authors": 0,
+                "external_pr_authors": 0,
+                "external_contributors": 0,
+                "latest_tag": "v0.8.0",
+                "latest_downloads": 4,
+            },
+            datetime(2026, 9, 3, tzinfo=timezone.utc),
+        )
+        self.assertIn("First-run feedback reports | 0 | 5 | 5 to go", report)
+        self.assertIn("CI matrix creates many automated checkouts", report)
+        self.assertIn("Ask five outside developers", report)
+        self.assertNotIn("210 | 210", report)
+
+    def test_report_does_not_turn_unavailable_traffic_into_zero(self) -> None:
+        report = MODULE["build_report"](
+            {
+                "repository": "sambai-dev/rookhold",
+                "stars": 11,
+                "forks": 0,
+                "watchers": 0,
+                "unique_views": None,
+                "unique_cloners": None,
+                "first_run_feedback": 0,
+                "external_issue_authors": 0,
+                "external_pr_authors": 0,
+                "external_contributors": 0,
+                "latest_tag": "v0.8.0",
+                "latest_downloads": 4,
+            },
+            datetime(2026, 9, 3, tzinfo=timezone.utc),
+        )
+        self.assertIn("Unavailable to workflow token", report)
+        self.assertNotIn("Unique repository visitors, rolling 14 days | 0", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_adoption_pulse.py
+++ b/scripts/tests/test_adoption_pulse.py
@@ -10,6 +10,23 @@ MODULE = runpy.run_path(str(ROOT / "scripts" / "adoption-pulse.py"))
 
 
 class AdoptionPulseTests(unittest.TestCase):
+    @staticmethod
+    def snapshot(first_run_feedback: int = 0) -> dict[str, object]:
+        return {
+            "repository": "sambai-dev/rookhold",
+            "stars": 11,
+            "forks": 0,
+            "watchers": 0,
+            "unique_views": 19,
+            "unique_cloners": 210,
+            "first_run_feedback": first_run_feedback,
+            "external_issue_authors": 0,
+            "external_pr_authors": 0,
+            "external_contributors": 0,
+            "latest_tag": "v0.8.0",
+            "latest_downloads": 4,
+        }
+
     def test_external_identity_filter_excludes_owner_and_bots(self) -> None:
         is_external = MODULE["is_external"]
         self.assertFalse(is_external("sambai-dev", "sambai-dev"))
@@ -19,26 +36,24 @@ class AdoptionPulseTests(unittest.TestCase):
 
     def test_report_prioritizes_first_runs_and_qualifies_clone_traffic(self) -> None:
         report = MODULE["build_report"](
-            {
-                "repository": "sambai-dev/rookhold",
-                "stars": 11,
-                "forks": 0,
-                "watchers": 0,
-                "unique_views": 19,
-                "unique_cloners": 210,
-                "first_run_feedback": 0,
-                "external_issue_authors": 0,
-                "external_pr_authors": 0,
-                "external_contributors": 0,
-                "latest_tag": "v0.8.0",
-                "latest_downloads": 4,
-            },
+            self.snapshot(),
             datetime(2026, 9, 3, tzinfo=timezone.utc),
         )
         self.assertIn("First-run feedback reports | 0 | 5 | 5 to go", report)
         self.assertIn("CI matrix creates many automated checkouts", report)
         self.assertIn("Ask five outside developers", report)
         self.assertNotIn("210 | 210", report)
+
+        for first_runs, expected in [
+            (4, "Ask five outside developers"),
+            (5, "Turn the most repeated first-run friction"),
+        ]:
+            with self.subTest(first_runs=first_runs):
+                boundary_report = MODULE["build_report"](
+                    self.snapshot(first_runs),
+                    datetime(2026, 9, 3, tzinfo=timezone.utc),
+                )
+                self.assertIn(expected, boundary_report)
 
     def test_report_does_not_turn_unavailable_traffic_into_zero(self) -> None:
         report = MODULE["build_report"](
@@ -60,6 +75,36 @@ class AdoptionPulseTests(unittest.TestCase):
         )
         self.assertIn("Unavailable to workflow token", report)
         self.assertNotIn("Unique repository visitors, rolling 14 days | 0", report)
+
+    def test_snapshot_handles_each_traffic_permission_failure(self) -> None:
+        class FakeClient:
+            def __init__(self, failed_path: str) -> None:
+                self.failed_path = failed_path
+
+            def get(self, path: str):
+                if self.failed_path in path:
+                    raise ValueError("permission denied")
+                if path.endswith("/traffic/views"):
+                    return {"uniques": 19}
+                if path.endswith("/traffic/clones"):
+                    return {"uniques": 210}
+                return {"stargazers_count": 11, "forks_count": 0, "subscribers_count": 0}
+
+            def all(self, path: str):
+                return []
+
+        for failed_path in ["/traffic/views", "/traffic/clones"]:
+            with self.subTest(failed_path=failed_path):
+                snapshot = MODULE["build_snapshot"](
+                    FakeClient(failed_path), "sambai-dev/rookhold"
+                )
+                self.assertIsNone(snapshot["unique_views"])
+                self.assertIsNone(snapshot["unique_cloners"])
+                report = MODULE["build_report"](
+                    snapshot,
+                    datetime(2026, 9, 3, tzinfo=timezone.utc),
+                )
+                self.assertIn("Unavailable to workflow token", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Contribution tier

Tier B — public feedback surface and bounded GitHub automation.

## Declared scope

Create a privacy-respecting GitHub-first loop that converts first runs into structured feedback and refreshes one conservative maintainer adoption pulse every week.

## Changes

- add a 60-second first-run issue form with outcome, install path, time-to-result, platform, and first-friction fields
- create and link a durable first-run Discussion, Q&A, and Show and tell paths
- add a concise Feedback guide and secondary homepage/quickstart/README links
- add a Sunday 20:17 UTC scheduled workflow that updates exactly one labeled adoption issue
- report first-run feedback, forks, outside contributors, stars, visitors when authorized, and latest release downloads
- exclude bots and explicitly reject CI-inflated clone traffic as an adoption KPI
- add a weekly private Codex adoption review that recommends one evidence-backed experiment without posting externally
- expand repository discovery topics with gVisor, Model Context Protocol, and secure execution

## Validation

- 48 support-script tests pass
- live adoption reporter reproduces current GitHub metrics
- unavailable traffic permissions remain unavailable rather than becoming fake zeroes
- release-surface and pinned-action checks pass
- issue form and workflow YAML parse
- VitePress production build passes
- Impeccable detector reports no findings for the feedback UI changes

## Safety and compatibility

Rookhold sends no hidden product telemetry. The automation reads GitHub repository aggregates and opt-in public reports only, never job contents or credentials. It has contents-read and issues-write permissions, a five-minute timeout, one exact title/label target, and fails closed if duplicate pulse issues exist. External social posting remains a separately reviewed action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a structured first-run feedback form covering outcomes, installation details, time to results, and the first point of confusion.
  - Added convenient links for asking questions, sharing projects, and providing first-run feedback.

- **Documentation**
  - Added a dedicated feedback guide with submission channels, useful reporting guidance, and privacy expectations.
  - Updated the README, documentation navigation, quickstart, homepage, and documentation index with feedback and secure-deployment links.
  - Improved documentation links for the production site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
